### PR TITLE
fix tests are too slow, fix deprecated warnings

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .venv
 test.db
+test.db-journal

--- a/backend/app/api/admin_users.py
+++ b/backend/app/api/admin_users.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, or_, select
@@ -101,7 +101,7 @@ async def update_user(
     target.sim_dcs = data.sim_dcs
     target.sim_bms = data.sim_bms
     target.need_presentation = data.need_presentation
-    target.updated_at = datetime.utcnow()
+    target.updated_at = datetime.now(UTC)
 
     try:
         await db.commit()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,6 +41,7 @@ packages = ["app"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,32 +3,48 @@ from collections.abc import AsyncGenerator
 
 import pytest
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from app.config import settings
 from app.database import Base, get_db
 from app.main import app
 
-# Use SQLite for tests (in-memory)
-TEST_DATABASE_URL = "sqlite+aiosqlite:///./test.db"
+# In-memory SQLite — schema created once per session for speed
+_engine = create_async_engine("sqlite+aiosqlite://", echo=False)
 
-engine = create_async_engine(TEST_DATABASE_URL, echo=False)
-TestSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+@pytest.fixture(scope="session")
+async def engine():
+    async with _engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield _engine
+    await _engine.dispose()
 
 
 @pytest.fixture(autouse=True)
-async def setup_database():
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
+async def db_session(engine) -> AsyncGenerator[AsyncSession, None]:
+    """Per-test session using savepoint (begin_nested) for isolation.
 
+    App-level commit/rollback only affects the savepoint; the outer
+    transaction is rolled back after each test to restore a clean DB.
+    """
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        nested = await conn.begin_nested()
 
-@pytest.fixture
-async def db_session() -> AsyncGenerator[AsyncSession, None]:
-    async with TestSessionLocal() as session:
+        session = AsyncSession(bind=conn, expire_on_commit=False)
+
+        # When app code calls session.commit() or session.rollback(),
+        # the savepoint ends. Restart it so subsequent operations still work.
+        @event.listens_for(session.sync_session, "after_transaction_end")
+        def _restart_savepoint(sync_session, sync_trans):
+            if conn.sync_connection is not None and not conn.sync_connection.in_nested_transaction():
+                sync_session.begin_nested()
+
         yield session
+        await session.close()
+        await trans.rollback()
 
 
 @pytest.fixture

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -12,6 +12,10 @@ from app.models.module import Module, ModuleRole, ModuleSystem
 from app.models.recruitment import RecruitmentEvent
 from app.models.user import User, UserModule
 
+# Pre-hashed "password123" — computed once at import time to avoid
+# repeated bcrypt hashing (~200ms each) in every test.
+_HASHED_PASSWORD = hash_password("password123")
+
 
 class UserFactory(factory.Factory):
     class Meta:
@@ -19,7 +23,7 @@ class UserFactory(factory.Factory):
 
     email = factory.Sequence(lambda n: f"user{n}@veaf.org")
     nickname = factory.Sequence(lambda n: f"Pilot{n}")
-    password = factory.LazyFunction(lambda: hash_password("password123"))
+    password = _HASHED_PASSWORD
     roles = "ROLE_USER"
     status = User.STATUS_MEMBER
     sim_dcs = True


### PR DESCRIPTION
## Summary by Sourcery

Speed up test suite and modernize datetime usage in admin APIs while improving transactional isolation for database tests.

Bug Fixes:
- Fix slow tests by reusing a single in-memory SQLite schema per session and isolating each test via savepoint-based transactions.
- Prevent premature autoflush when assigning module roles and systems during module creation to avoid related ORM issues.

Enhancements:
- Reuse a precomputed hashed password in factories to reduce test overhead from repeated password hashing.
- Switch admin module and user timestamp fields from naive utcnow() to timezone-aware datetime.now(UTC).
- Configure pytest asyncio fixture loop scope to session to align with the new database engine fixture lifecycle.

Tests:
- Refactor test database setup to use a session-scoped engine fixture and per-test transactional sessions with savepoints for faster, isolated async DB tests.