### PR TITLE
add server view

### DIFF
--- a/backend/app/api/dcsbot.py
+++ b/backend/app/api/dcsbot.py
@@ -1,6 +1,21 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 
-from app.schemas.dcs import DcsBotPageOut, DcsBotServerOut, DcsBotStatsOut, MissionInfoOut, PlayerEntryOut
+from app.auth.dependencies import get_optional_user
+from app.models.user import User
+from app.schemas.dcs import (
+    DcsBotAttendanceOut,
+    DcsBotPageOut,
+    DcsBotServerDetailOut,
+    DcsBotServerDetailPageOut,
+    DcsBotServerOut,
+    DcsBotStatsOut,
+    MissionInfoOut,
+    PlayerEntryOut,
+    TopMissionOut,
+    TopModuleOut,
+    TopTheatreOut,
+    WeatherInfoOut,
+)
 from app.services import dcsbot as dcsbot_service
 
 router = APIRouter(prefix="/dcsbot", tags=["dcsbot"])
@@ -42,3 +57,80 @@ async def get_dcsbot_servers():
         )
 
     return DcsBotPageOut(servers=items, stats=stats_out)
+
+
+def _build_stats(stats_data: dict) -> DcsBotStatsOut:
+    """Build DcsBotStatsOut from DCSServerBot API response (camelCase keys)."""
+    return DcsBotStatsOut(
+        total_players=stats_data.get("totalPlayers", 0),
+        active_players=stats_data.get("activePlayers", 0),
+        total_sorties=stats_data.get("totalSorties", 0),
+        avg_playtime=stats_data.get("avgPlaytime", 0),
+        total_kills=stats_data.get("totalKills", 0),
+        total_deaths=stats_data.get("totalDeaths", 0),
+        total_pvp_kills=stats_data.get("totalPvPKills", 0),
+        total_pvp_deaths=stats_data.get("totalPvPDeaths", 0),
+    )
+
+
+@router.get("/servers/{server_name}", response_model=DcsBotServerDetailPageOut)
+async def get_dcsbot_server(
+    server_name: str,
+    user: User | None = Depends(get_optional_user),
+):
+    servers_data = await dcsbot_service.get_server(server_name)
+    if not servers_data:
+        raise HTTPException(status_code=404, detail="Serveur non trouvé")
+
+    s = servers_data[0]
+    mission_raw = s.get("mission")
+    players_raw = s.get("players") or []
+    weather_raw = s.get("weather")
+
+    # Only expose password to authenticated cadets and members
+    password = s.get("password")
+    if not (user and (user.is_cadet or user.is_member)):
+        password = None
+
+    server_out = DcsBotServerDetailOut(
+        name=s.get("name", ""),
+        status=s.get("status", "Unknown"),
+        num_players=len(players_raw),
+        address=s.get("address"),
+        password=password,
+        restart_time=str(s["restart_time"]) if s.get("restart_time") else None,
+        mission=MissionInfoOut(**mission_raw) if mission_raw else None,
+        players=[PlayerEntryOut(**p) for p in players_raw],
+        weather=WeatherInfoOut(**weather_raw) if weather_raw else None,
+    )
+
+    # Per-server stats (camelCase keys from DCSServerBot API)
+    stats_data = await dcsbot_service.get_server_stats_by_name(server_name)
+    stats_out = _build_stats(stats_data) if stats_data else None
+
+    # Attendance (snake_case keys, optional)
+    attendance_data = await dcsbot_service.get_server_attendance(server_name)
+    attendance_out = None
+    if attendance_data:
+        attendance_out = DcsBotAttendanceOut(
+            current_players=attendance_data.get("current_players", 0),
+            unique_players_24h=attendance_data.get("unique_players_24h", 0),
+            total_playtime_hours_24h=attendance_data.get("total_playtime_hours_24h", 0),
+            discord_members_24h=attendance_data.get("discord_members_24h", 0),
+            unique_players_7d=attendance_data.get("unique_players_7d", 0),
+            total_playtime_hours_7d=attendance_data.get("total_playtime_hours_7d", 0),
+            discord_members_7d=attendance_data.get("discord_members_7d", 0),
+            unique_players_30d=attendance_data.get("unique_players_30d", 0),
+            total_playtime_hours_30d=attendance_data.get("total_playtime_hours_30d", 0),
+            discord_members_30d=attendance_data.get("discord_members_30d", 0),
+            total_sorties=attendance_data.get("total_sorties"),
+            total_kills=attendance_data.get("total_kills"),
+            total_deaths=attendance_data.get("total_deaths"),
+            total_pvp_kills=attendance_data.get("total_pvp_kills"),
+            total_pvp_deaths=attendance_data.get("total_pvp_deaths"),
+            top_theatres=[TopTheatreOut(**t) for t in attendance_data.get("top_theatres") or []],
+            top_missions=[TopMissionOut(**m) for m in attendance_data.get("top_missions") or []],
+            top_modules=[TopModuleOut(**m) for m in attendance_data.get("top_modules") or []],
+        )
+
+    return DcsBotServerDetailPageOut(server=server_out, stats=stats_out, attendance=attendance_out)

--- a/backend/app/schemas/dcs.py
+++ b/backend/app/schemas/dcs.py
@@ -58,6 +58,78 @@ class DcsBotPageOut(BaseModel):
     stats: DcsBotStatsOut | None = None
 
 
+# --- DCSServerBot server detail schemas ---
+
+
+class WeatherInfoOut(BaseModel):
+    temperature: float | None = None
+    wind_speed: float | None = None
+    wind_direction: int | None = None
+    pressure: float | None = None
+    visibility: int | None = None
+    clouds_base: int | None = None
+    clouds_density: int | None = None
+    precipitation: int | None = None
+    fog_enabled: bool | None = None
+    fog_visibility: int | None = None
+    dust_enabled: bool | None = None
+    dust_visibility: int | None = None
+
+
+class DcsBotServerDetailOut(BaseModel):
+    name: str
+    status: str
+    num_players: int
+    address: str | None = None
+    password: str | None = None
+    restart_time: str | None = None
+    mission: MissionInfoOut | None = None
+    players: list[PlayerEntryOut] = Field(default_factory=list)
+    weather: WeatherInfoOut | None = None
+
+
+class TopTheatreOut(BaseModel):
+    theatre: str
+    playtime_hours: float
+
+
+class TopMissionOut(BaseModel):
+    mission_name: str
+    playtime_hours: float
+
+
+class TopModuleOut(BaseModel):
+    module: str
+    playtime_hours: float
+
+
+class DcsBotAttendanceOut(BaseModel):
+    current_players: int
+    unique_players_24h: int
+    total_playtime_hours_24h: float
+    discord_members_24h: int
+    unique_players_7d: int
+    total_playtime_hours_7d: float
+    discord_members_7d: int
+    unique_players_30d: int
+    total_playtime_hours_30d: float
+    discord_members_30d: int
+    total_sorties: int | None = None
+    total_kills: int | None = None
+    total_deaths: int | None = None
+    total_pvp_kills: int | None = None
+    total_pvp_deaths: int | None = None
+    top_theatres: list[TopTheatreOut] = Field(default_factory=list)
+    top_missions: list[TopMissionOut] = Field(default_factory=list)
+    top_modules: list[TopModuleOut] = Field(default_factory=list)
+
+
+class DcsBotServerDetailPageOut(BaseModel):
+    server: DcsBotServerDetailOut
+    stats: DcsBotStatsOut | None = None
+    attendance: DcsBotAttendanceOut | None = None
+
+
 # --- DB entity schemas ---
 
 

--- a/backend/app/services/dcsbot.py
+++ b/backend/app/services/dcsbot.py
@@ -34,3 +34,51 @@ async def get_server_stats() -> dict | None:
     except Exception:
         logger.exception("Failed to fetch DCSServerBot server stats")
         return None
+
+
+@cached(dcsbot_cache)
+async def get_server(server_name: str) -> list[dict] | None:
+    """Fetch a specific server from DCSServerBot API by server_name."""
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.get(
+                f"{settings.API_DCSSERVERBOT_URL}/serverapi/servers",
+                params={"server_name": server_name},
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        logger.exception("Failed to fetch DCSServerBot server %s", server_name)
+        return None
+
+
+@cached(dcsbot_cache)
+async def get_server_stats_by_name(server_name: str) -> dict | None:
+    """Fetch server-specific statistics from DCSServerBot API."""
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.get(
+                f"{settings.API_DCSSERVERBOT_URL}/serverapi/serverstats",
+                params={"server_name": server_name},
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        logger.exception("Failed to fetch DCSServerBot stats for %s", server_name)
+        return None
+
+
+@cached(dcsbot_cache)
+async def get_server_attendance(server_name: str) -> dict | None:
+    """Fetch server attendance from DCSServerBot API."""
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.get(
+                f"{settings.API_DCSSERVERBOT_URL}/serverapi/server_attendance",
+                params={"server_name": server_name},
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        logger.exception("Failed to fetch DCSServerBot attendance for %s", server_name)
+        return None

--- a/frontend/src/api/servers.ts
+++ b/frontend/src/api/servers.ts
@@ -1,5 +1,5 @@
 import apiClient from './client'
-import type { Server, HeaderData, DcsBotPage } from '@/types/api'
+import type { Server, HeaderData, DcsBotPage, DcsBotServerDetailPage } from '@/types/api'
 
 export async function getServers(): Promise<Server[]> {
   const { data } = await apiClient.get<Server[]>('/servers')
@@ -13,5 +13,10 @@ export async function getHeaderData(): Promise<HeaderData> {
 
 export async function getDcsBotServers(): Promise<DcsBotPage> {
   const { data } = await apiClient.get<DcsBotPage>('/dcsbot/servers')
+  return data
+}
+
+export async function getDcsBotServer(serverName: string): Promise<DcsBotServerDetailPage> {
+  const { data } = await apiClient.get<DcsBotServerDetailPage>(`/dcsbot/servers/${encodeURIComponent(serverName)}`)
   return data
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -60,6 +60,12 @@ const router = createRouter({
       component: () => import('@/views/ServersView.vue'),
     },
     {
+      path: '/servers/:serverName',
+      name: 'server-detail',
+      component: () => import('@/views/ServerDetailView.vue'),
+      props: true,
+    },
+    {
       path: '/user/:id',
       name: 'user-profile',
       component: () => import('@/views/UserProfileView.vue'),

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -54,6 +54,10 @@ export interface MissionInfo {
   uptime: number
   date_time: string | null
   theatre: string
+  blue_slots: number | null
+  blue_slots_used: number | null
+  red_slots: number | null
+  red_slots_used: number | null
 }
 
 export interface PlayerEntry {
@@ -85,6 +89,77 @@ export interface DcsBotStats {
 export interface DcsBotPage {
   servers: DcsBotServer[]
   stats: DcsBotStats | null
+}
+
+// DCSServerBot server detail types
+
+export interface WeatherInfo {
+  temperature: number | null
+  wind_speed: number | null
+  wind_direction: number | null
+  pressure: number | null
+  visibility: number | null
+  clouds_base: number | null
+  clouds_density: number | null
+  precipitation: number | null
+  fog_enabled: boolean | null
+  fog_visibility: number | null
+  dust_enabled: boolean | null
+  dust_visibility: number | null
+}
+
+export interface DcsBotServerDetail {
+  name: string
+  status: string
+  num_players: number
+  address: string | null
+  password: string | null
+  restart_time: string | null
+  mission: MissionInfo | null
+  players: PlayerEntry[]
+  weather: WeatherInfo | null
+}
+
+export interface TopTheatre {
+  theatre: string
+  playtime_hours: number
+}
+
+export interface TopMission {
+  mission_name: string
+  playtime_hours: number
+}
+
+export interface TopModule {
+  module: string
+  playtime_hours: number
+}
+
+export interface DcsBotAttendance {
+  current_players: number
+  unique_players_24h: number
+  total_playtime_hours_24h: number
+  discord_members_24h: number
+  unique_players_7d: number
+  total_playtime_hours_7d: number
+  discord_members_7d: number
+  unique_players_30d: number
+  total_playtime_hours_30d: number
+  discord_members_30d: number
+  total_sorties: number | null
+  total_kills: number | null
+  total_deaths: number | null
+  total_pvp_kills: number | null
+  total_pvp_deaths: number | null
+  top_theatres: TopTheatre[]
+  top_missions: TopMission[]
+  top_modules: TopModule[]
+}
+
+export interface DcsBotServerDetailPage {
+  server: DcsBotServerDetail
+  stats: DcsBotStats | null
+  attendance: DcsBotAttendance | null
 }
 
 export interface HeaderData {

--- a/frontend/src/views/ServerDetailView.vue
+++ b/frontend/src/views/ServerDetailView.vue
@@ -1,0 +1,595 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { RouterLink } from 'vue-router'
+import { getDcsBotServer } from '@/api/servers'
+import type { DcsBotServerDetailPage } from '@/types/api'
+
+const POLL_INTERVAL = 60_000
+
+const props = defineProps<{ serverName: string }>()
+
+const pageData = ref<DcsBotServerDetailPage | null>(null)
+const loading = ref(true)
+const error = ref(false)
+const showPassword = ref(false)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+async function fetchData() {
+  loading.value = true
+  error.value = false
+  try {
+    pageData.value = await getDcsBotServer(props.serverName)
+  } catch {
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+async function refreshData() {
+  try {
+    pageData.value = await getDcsBotServer(props.serverName)
+    error.value = false
+  } catch {
+    // Keep previous data on refresh error
+  }
+}
+
+onMounted(() => {
+  fetchData()
+  pollTimer = setInterval(refreshData, POLL_INTERVAL)
+})
+
+onUnmounted(() => {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+})
+
+// --- Helper functions ---
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'Running': return 'bg-green-100 text-green-800'
+    case 'Paused': return 'bg-yellow-100 text-yellow-800'
+    case 'Shutdown': return 'bg-gray-200 text-gray-600'
+    default: return 'bg-blue-100 text-blue-800'
+  }
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'Running': return 'fa-solid fa-play'
+    case 'Paused': return 'fa-solid fa-pause'
+    case 'Shutdown': return 'fa-solid fa-stop'
+    default: return 'fa-solid fa-question'
+  }
+}
+
+function sideBadgeClass(side: string | null): string {
+  switch (side?.toLowerCase()) {
+    case 'blue': return 'bg-blue-100 text-blue-800'
+    case 'red': return 'bg-red-100 text-red-800'
+    default: return 'bg-gray-200 text-gray-600'
+  }
+}
+
+function formatMissionName(name: string): string {
+  return name.replace(/_/g, ' ')
+}
+
+function formatUptime(seconds: number): string {
+  return Math.round(seconds / 60) + 'min'
+}
+
+function formatAvgPlaytime(seconds: number): string {
+  return (seconds / 3600).toFixed(1) + 'h'
+}
+
+function formatRestartTime(raw: string): string {
+  try {
+    const d = new Date(raw)
+    return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return raw
+  }
+}
+
+// Weather conversions
+function tempF(c: number): string {
+  return ((c * 9 / 5) + 32).toFixed(1)
+}
+
+function pressureHpa(mmHg: number): string {
+  return Math.round(mmHg * 1013.25 / 760).toString()
+}
+
+function pressureInHg(mmHg: number): string {
+  return (mmHg / 25.4).toFixed(2)
+}
+
+function windDir(dir: number): string {
+  return Math.round((dir + 180) % 360).toString()
+}
+
+function windKts(ms: number): string {
+  return (ms * 1.94384).toFixed(1)
+}
+
+function windKmh(ms: number): string {
+  return (ms * 3.6).toFixed(1)
+}
+
+function cloudBaseFt(m: number): string {
+  return Math.round(m * 3.28084).toString()
+}
+
+function visKm(m: number): string {
+  return (m / 1000).toFixed(1)
+}
+
+function visNm(m: number): string {
+  return (m / 1852).toFixed(1)
+}
+</script>
+
+<template>
+  <div>
+    <!-- Breadcrumb -->
+    <nav class="text-sm text-gray-500 mb-4">
+      <RouterLink to="/servers" class="text-veaf-600 hover:text-veaf-800 hover:underline">
+        Serveurs DCS
+      </RouterLink>
+      <span class="mx-2">/</span>
+      <span class="text-gray-700">{{ props.serverName }}</span>
+    </nav>
+
+    <!-- Loading -->
+    <div v-if="loading" class="text-center py-8 text-gray-500">Chargement...</div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="card text-center py-8 text-red-600">
+      <i class="fa-solid fa-exclamation-triangle mr-1"></i>
+      Impossible de contacter le service DCSServerBot
+      <button @click="fetchData" class="btn-primary text-sm ml-4">Réessayer</button>
+    </div>
+
+    <template v-else-if="pageData">
+      <!-- Title + status badge -->
+      <h1 class="text-2xl font-bold mb-6">
+        <i class="fa-solid fa-server mr-2"></i>{{ pageData.server.name }}
+        <span
+          :class="statusBadgeClass(pageData.server.status)"
+          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ml-2 align-middle"
+        >
+          <i :class="statusIcon(pageData.server.status)" class="mr-1"></i>
+          {{ pageData.server.status }}
+        </span>
+      </h1>
+
+      <!-- Server info + Mission (two-column) -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        <!-- Server info card -->
+        <div class="card">
+          <h2 class="font-bold text-lg mb-3 border-b pb-2">
+            <i class="fa-solid fa-server mr-1"></i> Informations serveur
+          </h2>
+          <table class="w-full text-sm">
+            <tbody>
+              <tr v-if="pageData.server.address">
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-network-wired mr-1"></i> Adresse
+                </th>
+                <td>{{ pageData.server.address }}</td>
+              </tr>
+              <tr v-if="pageData.server.password">
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-key mr-1"></i> Mot de passe
+                </th>
+                <td>
+                  <i
+                    :class="showPassword ? 'fa-solid fa-eye' : 'fa-solid fa-eye-slash'"
+                    class="cursor-pointer mr-2 text-gray-500 hover:text-gray-700"
+                    title="Cliquer pour révéler"
+                    @click="showPassword = !showPassword"
+                  ></i>
+                  <span>{{ showPassword ? pageData.server.password : '******' }}</span>
+                </td>
+              </tr>
+              <tr v-if="pageData.server.restart_time">
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-arrows-rotate mr-1"></i> Prochain redémarrage
+                </th>
+                <td>{{ formatRestartTime(pageData.server.restart_time) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mission card -->
+        <div v-if="pageData.server.mission" class="card">
+          <h2 class="font-bold text-lg mb-3 border-b pb-2">
+            <i class="fa-solid fa-fighter-jet mr-1"></i> Mission en cours
+          </h2>
+          <table class="w-full text-sm">
+            <tbody>
+              <tr>
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-file-lines mr-1"></i> Nom
+                </th>
+                <td :title="formatMissionName(pageData.server.mission.name)">
+                  {{ formatMissionName(pageData.server.mission.name) }}
+                </td>
+              </tr>
+              <tr>
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-map mr-1"></i> Théâtre
+                </th>
+                <td>{{ pageData.server.mission.theatre }}</td>
+              </tr>
+              <tr v-if="pageData.server.mission.date_time">
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-sun mr-1"></i> Heure mission
+                </th>
+                <td>{{ pageData.server.mission.date_time }}</td>
+              </tr>
+              <tr>
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-clock mr-1"></i> Uptime
+                </th>
+                <td>{{ formatUptime(pageData.server.mission.uptime) }}</td>
+              </tr>
+              <tr>
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-users mr-1 text-blue-600"></i> Slots bleus
+                </th>
+                <td>{{ pageData.server.mission.blue_slots_used ?? 0 }} / {{ pageData.server.mission.blue_slots ?? '?' }}</td>
+              </tr>
+              <tr>
+                <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                  <i class="fa-solid fa-users mr-1 text-red-600"></i> Slots rouges
+                </th>
+                <td>{{ pageData.server.mission.red_slots_used ?? 0 }} / {{ pageData.server.mission.red_slots ?? '?' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Weather -->
+      <template v-if="pageData.server.weather">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          <!-- Temperature / QNH -->
+          <div class="card">
+            <h2 class="font-bold text-lg mb-3 border-b pb-2">
+              <i class="fa-solid fa-cloud-sun mr-1"></i> Conditions météo
+            </h2>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr v-if="pageData.server.weather.temperature != null">
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-temperature-high mr-1"></i> Température
+                  </th>
+                  <td>{{ pageData.server.weather.temperature.toFixed(1) }} °C</td>
+                  <td>{{ tempF(pageData.server.weather.temperature) }} °F</td>
+                </tr>
+                <tr v-if="pageData.server.weather.pressure != null">
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-gauge mr-1"></i> QNH
+                  </th>
+                  <td>{{ pressureHpa(pageData.server.weather.pressure) }} hPa</td>
+                  <td>{{ pressureInHg(pageData.server.weather.pressure) }} inHg</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Wind -->
+          <div class="card">
+            <h2 class="font-bold text-lg mb-3 border-b pb-2">
+              <i class="fa-solid fa-wind mr-1"></i> Vent au sol
+            </h2>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr v-if="pageData.server.weather.wind_direction != null">
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-compass mr-1"></i> Direction
+                  </th>
+                  <td colspan="3">{{ windDir(pageData.server.weather.wind_direction) }}°</td>
+                </tr>
+                <tr v-if="pageData.server.weather.wind_speed != null">
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-gauge mr-1"></i> Vitesse
+                  </th>
+                  <td>{{ windKts(pageData.server.weather.wind_speed) }} kts</td>
+                  <td>{{ windKmh(pageData.server.weather.wind_speed) }} km/h</td>
+                  <td>{{ pageData.server.weather.wind_speed.toFixed(0) }} m/s</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          <!-- Clouds -->
+          <div class="card">
+            <h2 class="font-bold text-lg mb-3 border-b pb-2">
+              <i class="fa-solid fa-cloud mr-1"></i> Nuages
+            </h2>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr>
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-arrows-up-down mr-1"></i> Base
+                  </th>
+                  <td>{{ pageData.server.weather.clouds_base ? pageData.server.weather.clouds_base + ' m' : '-' }}</td>
+                  <td>{{ pageData.server.weather.clouds_base ? cloudBaseFt(pageData.server.weather.clouds_base) + ' ft' : '-' }}</td>
+                </tr>
+                <tr>
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-th mr-1"></i> Densité
+                  </th>
+                  <td colspan="2">{{ pageData.server.weather.clouds_density ?? '-' }}/10</td>
+                </tr>
+                <tr v-if="pageData.server.weather.precipitation && pageData.server.weather.precipitation > 0">
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-cloud-rain mr-1"></i> Précipitations
+                  </th>
+                  <td colspan="2">Oui</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Visibility -->
+          <div class="card">
+            <h2 class="font-bold text-lg mb-3 border-b pb-2">
+              <i class="fa-solid fa-eye mr-1"></i> Visibilité
+            </h2>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr>
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-binoculars mr-1"></i> Distance
+                  </th>
+                  <td>{{ pageData.server.weather.visibility ? visKm(pageData.server.weather.visibility) + ' km' : '-' }}</td>
+                  <td>{{ pageData.server.weather.visibility ? visNm(pageData.server.weather.visibility) + ' NM' : '-' }}</td>
+                </tr>
+                <tr v-if="pageData.server.weather.fog_enabled">
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-smog mr-1"></i> Brouillard
+                  </th>
+                  <td colspan="2">{{ pageData.server.weather.fog_visibility }} m</td>
+                </tr>
+                <tr v-if="pageData.server.weather.dust_enabled">
+                  <th class="text-left py-1.5 pr-4 text-gray-600 w-40">
+                    <i class="fa-solid fa-wind mr-1"></i> Poussière
+                  </th>
+                  <td colspan="2">{{ pageData.server.weather.dust_visibility }} m</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </template>
+
+      <!-- Online players -->
+      <div v-if="pageData.server.status === 'Running' && pageData.server.players.length > 0" class="mb-6">
+        <h2 class="text-xl font-bold mb-4">
+          <i class="fa-solid fa-users mr-2"></i>Joueurs en ligne ({{ pageData.server.players.length }})
+        </h2>
+        <div class="card overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b bg-gray-50">
+                <th class="text-left py-2 px-3"><i class="fa-solid fa-user mr-1"></i>Pseudo</th>
+                <th class="text-left py-2 px-3"><i class="fa-solid fa-id-badge mr-1"></i>Callsign</th>
+                <th class="text-left py-2 px-3"><i class="fa-solid fa-flag mr-1"></i>Camp</th>
+                <th class="text-left py-2 px-3"><i class="fa-solid fa-plane mr-1"></i>Appareil</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="(player, index) in pageData.server.players"
+                :key="index"
+                class="border-b hover:bg-gray-50"
+              >
+                <td class="py-2 px-3">{{ player.nick }}</td>
+                <td class="py-2 px-3">{{ player.callsign ?? '-' }}</td>
+                <td class="py-2 px-3">
+                  <span
+                    v-if="player.side"
+                    :class="sideBadgeClass(player.side)"
+                    class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                  >
+                    {{ player.side }}
+                  </span>
+                  <span v-else class="text-gray-400">-</span>
+                </td>
+                <td class="py-2 px-3">{{ player.unit_type ?? '-' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Server statistics -->
+      <div v-if="pageData.stats" class="mb-6">
+        <h2 class="text-xl font-bold mb-4">
+          <i class="fa-solid fa-chart-bar mr-2"></i>Statistiques du serveur
+        </h2>
+
+        <!-- Primary stats -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
+          <div class="rounded-lg p-4 text-center text-white bg-veaf-600">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-users mr-1"></i>Joueurs total</div>
+            <div class="text-3xl font-bold">{{ pageData.stats.total_players }}</div>
+          </div>
+          <div class="rounded-lg p-4 text-center text-white bg-green-600">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-user-check mr-1"></i>Joueurs actifs</div>
+            <div class="text-3xl font-bold">{{ pageData.stats.active_players }}</div>
+          </div>
+          <div class="rounded-lg p-4 text-center text-white bg-sky-600">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-plane-departure mr-1"></i>Sorties</div>
+            <div class="text-3xl font-bold">{{ pageData.stats.total_sorties }}</div>
+          </div>
+          <div class="rounded-lg p-4 text-center text-white bg-gray-500">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-hourglass-half mr-1"></i>Temps moyen</div>
+            <div class="text-3xl font-bold">{{ formatAvgPlaytime(pageData.stats.avg_playtime) }}</div>
+          </div>
+        </div>
+
+        <!-- Secondary stats -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-crosshairs mr-1"></i>Kills</div>
+            <div class="text-2xl font-bold">{{ pageData.stats.total_kills }}</div>
+          </div>
+          <div class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-skull mr-1"></i>Deaths</div>
+            <div class="text-2xl font-bold">{{ pageData.stats.total_deaths }}</div>
+          </div>
+          <div class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-crosshairs mr-1 text-red-600"></i>PvP Kills</div>
+            <div class="text-2xl font-bold">{{ pageData.stats.total_pvp_kills }}</div>
+          </div>
+          <div class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-skull-crossbones mr-1 text-red-600"></i>PvP Deaths</div>
+            <div class="text-2xl font-bold">{{ pageData.stats.total_pvp_deaths }}</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Attendance -->
+      <template v-if="pageData.attendance">
+        <h2 class="text-xl font-bold mb-4">
+          <i class="fa-solid fa-chart-line mr-2"></i>Fréquentation du serveur
+        </h2>
+
+        <!-- Summary cards -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+          <div class="rounded-lg p-4 text-center text-white bg-veaf-600">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-user-clock mr-1"></i>Joueurs actuels</div>
+            <div class="text-3xl font-bold">{{ pageData.attendance.current_players }}</div>
+          </div>
+          <div class="rounded-lg p-4 text-center text-white bg-green-600">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-calendar-day mr-1"></i>Uniques 24h</div>
+            <div class="text-3xl font-bold">{{ pageData.attendance.unique_players_24h }}</div>
+          </div>
+          <div class="rounded-lg p-4 text-center text-white bg-sky-600">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-calendar-week mr-1"></i>Uniques 7j</div>
+            <div class="text-3xl font-bold">{{ pageData.attendance.unique_players_7d }}</div>
+          </div>
+          <div class="rounded-lg p-4 text-center text-white bg-gray-500">
+            <div class="text-sm font-medium mb-1"><i class="fa-solid fa-calendar mr-1"></i>Uniques 30j</div>
+            <div class="text-3xl font-bold">{{ pageData.attendance.unique_players_30d }}</div>
+          </div>
+        </div>
+
+        <!-- Period comparison table -->
+        <div class="card mb-6 overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b bg-gray-50">
+                <th class="text-left py-2 px-3"><i class="fa-solid fa-calendar mr-1"></i>Période</th>
+                <th class="text-left py-2 px-3"><i class="fa-solid fa-user mr-1"></i>Joueurs uniques</th>
+                <th class="text-left py-2 px-3"><i class="fa-solid fa-clock mr-1"></i>Temps de jeu total</th>
+                <th class="text-left py-2 px-3"><i class="fa-brands fa-discord mr-1"></i>Membres Discord</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b hover:bg-gray-50">
+                <td class="py-2 px-3">24 heures</td>
+                <td class="py-2 px-3">{{ pageData.attendance.unique_players_24h }}</td>
+                <td class="py-2 px-3">{{ pageData.attendance.total_playtime_hours_24h.toFixed(1) }}h</td>
+                <td class="py-2 px-3">{{ pageData.attendance.discord_members_24h }}</td>
+              </tr>
+              <tr class="border-b hover:bg-gray-50">
+                <td class="py-2 px-3">7 jours</td>
+                <td class="py-2 px-3">{{ pageData.attendance.unique_players_7d }}</td>
+                <td class="py-2 px-3">{{ pageData.attendance.total_playtime_hours_7d.toFixed(1) }}h</td>
+                <td class="py-2 px-3">{{ pageData.attendance.discord_members_7d }}</td>
+              </tr>
+              <tr class="hover:bg-gray-50">
+                <td class="py-2 px-3">30 jours</td>
+                <td class="py-2 px-3">{{ pageData.attendance.unique_players_30d }}</td>
+                <td class="py-2 px-3">{{ pageData.attendance.total_playtime_hours_30d.toFixed(1) }}h</td>
+                <td class="py-2 px-3">{{ pageData.attendance.discord_members_30d }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Combat stats -->
+        <div v-if="pageData.attendance.total_sorties != null" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-6">
+          <div class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-plane-departure mr-1"></i>Sorties</div>
+            <div class="text-xl font-bold">{{ pageData.attendance.total_sorties }}</div>
+          </div>
+          <div v-if="pageData.attendance.total_kills != null" class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-crosshairs mr-1"></i>Kills</div>
+            <div class="text-xl font-bold">{{ pageData.attendance.total_kills }}</div>
+          </div>
+          <div v-if="pageData.attendance.total_deaths != null" class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-skull mr-1"></i>Deaths</div>
+            <div class="text-xl font-bold">{{ pageData.attendance.total_deaths }}</div>
+          </div>
+          <div v-if="pageData.attendance.total_pvp_kills != null" class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-crosshairs mr-1 text-red-600"></i>PvP Kills</div>
+            <div class="text-xl font-bold">{{ pageData.attendance.total_pvp_kills }}</div>
+          </div>
+          <div v-if="pageData.attendance.total_pvp_deaths != null" class="card text-center">
+            <div class="text-sm text-gray-600 mb-1"><i class="fa-solid fa-skull-crossbones mr-1 text-red-600"></i>PvP Deaths</div>
+            <div class="text-xl font-bold">{{ pageData.attendance.total_pvp_deaths }}</div>
+          </div>
+        </div>
+
+        <!-- Top lists -->
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+          <div v-if="pageData.attendance.top_theatres.length > 0" class="card">
+            <h3 class="font-bold mb-3 border-b pb-2">
+              <i class="fa-solid fa-globe mr-1"></i> Top Théâtres
+            </h3>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr v-for="t in pageData.attendance.top_theatres" :key="t.theatre" class="border-b last:border-b-0">
+                  <td class="py-1.5">{{ t.theatre }}</td>
+                  <td class="py-1.5 text-right text-gray-600">{{ t.playtime_hours.toFixed(1) }}h</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div v-if="pageData.attendance.top_missions.length > 0" class="card">
+            <h3 class="font-bold mb-3 border-b pb-2">
+              <i class="fa-solid fa-list-check mr-1"></i> Top Missions
+            </h3>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr v-for="m in pageData.attendance.top_missions" :key="m.mission_name" class="border-b last:border-b-0">
+                  <td class="py-1.5">{{ formatMissionName(m.mission_name) }}</td>
+                  <td class="py-1.5 text-right text-gray-600">{{ m.playtime_hours.toFixed(1) }}h</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div v-if="pageData.attendance.top_modules.length > 0" class="card">
+            <h3 class="font-bold mb-3 border-b pb-2">
+              <i class="fa-solid fa-fighter-jet mr-1"></i> Top Modules
+            </h3>
+            <table class="w-full text-sm">
+              <tbody>
+                <tr v-for="m in pageData.attendance.top_modules" :key="m.module" class="border-b last:border-b-0">
+                  <td class="py-1.5">{{ formatMissionName(m.module) }}</td>
+                  <td class="py-1.5 text-right text-gray-600">{{ m.playtime_hours.toFixed(1) }}h</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>

--- a/frontend/src/views/ServersView.vue
+++ b/frontend/src/views/ServersView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
 import { getDcsBotServers } from '@/api/servers'
 import type { DcsBotPage } from '@/types/api'
 
@@ -105,7 +106,14 @@ function formatAvgPlaytime(seconds: number): string {
               :key="server.name"
               class="border-b hover:bg-gray-50"
             >
-              <td class="py-2 px-3 font-medium">{{ shortName(server.name) }}</td>
+              <td class="py-2 px-3 font-medium">
+                <RouterLink
+                  :to="{ name: 'server-detail', params: { serverName: server.name } }"
+                  class="text-veaf-600 hover:text-veaf-800 hover:underline"
+                >
+                  {{ shortName(server.name) }}
+                </RouterLink>
+              </td>
               <td class="py-2 px-3">
                 <span
                   :class="statusBadgeClass(server.status)"


### PR DESCRIPTION
## Summary by Sourcery

Add a detailed per-server DCSServerBot view, including mission, weather, players, statistics and attendance, and wire it through backend API, shared schemas, frontend types, routing and UI.

New Features:
- Expose a new backend endpoint to fetch detailed information for a single DCSServerBot server, including mission, weather, statistics and attendance.
- Introduce frontend API types, client call and a dedicated Server Detail view with live polling to display rich server information, weather, online players, statistics and attendance history.
- Add support for mission slot counts to the shared MissionInfo schema and surface them in the UI.

Enhancements:
- Restrict server password visibility to authenticated cadets and members via optional user dependency on the new endpoint.
- Make server names in the servers list clickable links that navigate to the new server detail page.