### PR TITLE
add markdown editor and rendering

### DIFF
--- a/backend/fixtures/content.py
+++ b/backend/fixtures/content.py
@@ -14,7 +14,7 @@ PAGES_DATA = [
     {"key": "status", "route": "status", "path": "fr/association/statuts", "title": "Les status", "enabled": True, "restriction": Page.LEVEL_ALL, "created_at": _TS1, "updated_at": _TS2},
     {"key": "guest", "route": "guest", "path": "fr/restriction/guest", "title": "Guest", "enabled": True, "restriction": Page.LEVEL_GUEST, "created_at": _TS1, "updated_at": _TS2},
     {"key": "cadet", "route": "cadet", "path": "fr/restriction/cadet", "title": "Cadet", "enabled": True, "restriction": Page.LEVEL_CADET, "created_at": _TS1, "updated_at": _TS2},
-    {"key": "member", "route": "member", "path": "fr/restriction/member", "title": "Cadet", "enabled": True, "restriction": Page.LEVEL_MEMBER, "created_at": _TS1, "updated_at": _TS2},
+    {"key": "member", "route": "member", "path": "fr/restriction/member", "title": "Member", "enabled": True, "restriction": Page.LEVEL_MEMBER, "created_at": _TS1, "updated_at": _TS2},
 ]
 
 URLS_DATA = [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,12 +15,15 @@
         "@fullcalendar/timegrid": "^6.1.20",
         "@fullcalendar/vue3": "^6.1.20",
         "axios": "^1.7.0",
+        "dompurify": "^3.3.1",
+        "marked": "^17.0.3",
         "pinia": "^2.2.0",
         "vue": "^3.5.0",
         "vue-router": "^4.4.0",
         "vue-toastification": "^2.0.0-rc.5"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@vitejs/plugin-vue": "^5.2.0",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
@@ -1016,11 +1019,28 @@
         "win32"
       ]
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1701,6 +1721,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2198,6 +2227,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
+      "integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,12 +18,15 @@
     "@fullcalendar/timegrid": "^6.1.20",
     "@fullcalendar/vue3": "^6.1.20",
     "axios": "^1.7.0",
+    "dompurify": "^3.3.1",
+    "marked": "^17.0.3",
     "pinia": "^2.2.0",
     "vue": "^3.5.0",
     "vue-router": "^4.4.0",
     "vue-toastification": "^2.0.0-rc.5"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@vitejs/plugin-vue": "^5.2.0",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",

--- a/frontend/src/components/ui/MarkdownEditor.vue
+++ b/frontend/src/components/ui/MarkdownEditor.vue
@@ -1,0 +1,299 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { uploadFile } from '@/api/files'
+import { renderMarkdown } from '@/composables/useMarkdown'
+import { useToast } from '@/composables/useToast'
+
+const props = withDefaults(defineProps<{
+  modelValue: string
+  rows?: number
+  placeholder?: string
+}>(), {
+  rows: 8,
+  placeholder: '',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const toast = useToast()
+const textarea = ref<HTMLTextAreaElement | null>(null)
+const activeTab = ref<'edit' | 'preview'>('edit')
+const dragging = ref(false)
+const uploading = ref(false)
+
+const preview = computed(() => renderMarkdown(props.modelValue))
+
+// --- Toolbar actions ---
+
+interface ToolbarAction {
+  icon: string
+  title: string
+  size?: string
+  action: () => void
+}
+
+const toolbarActions: ToolbarAction[] = [
+  { icon: 'fa-solid fa-bold', title: 'Gras', action: () => wrapSelection('**', '**') },
+  { icon: 'fa-solid fa-italic', title: 'Italique', action: () => wrapSelection('*', '*') },
+  { icon: 'fa-solid fa-heading', title: 'Titre 2', action: () => prefixLine('## ') },
+  { icon: 'fa-solid fa-heading', title: 'Titre 3', size: 'text-xs', action: () => prefixLine('### ') },
+  { icon: 'fa-solid fa-list-ul', title: 'Liste', action: () => prefixLine('- ') },
+  { icon: 'fa-solid fa-list-ol', title: 'Liste numérotée', action: () => prefixLine('1. ') },
+  { icon: 'fa-solid fa-link', title: 'Lien', action: () => insertLink() },
+  { icon: 'fa-solid fa-image', title: 'Image', action: () => triggerImageUpload() },
+  { icon: 'fa-solid fa-code', title: 'Code', action: () => wrapSelection('`', '`') },
+  { icon: 'fa-solid fa-quote-left', title: 'Citation', action: () => prefixLine('> ') },
+]
+
+function wrapSelection(before: string, after: string) {
+  const el = textarea.value
+  if (!el) return
+  const start = el.selectionStart
+  const end = el.selectionEnd
+  const text = props.modelValue
+  const selected = text.slice(start, end) || 'texte'
+  const newText = text.slice(0, start) + before + selected + after + text.slice(end)
+  emit('update:modelValue', newText)
+  // Restore cursor after Vue re-renders
+  const cursorPos = start + before.length + selected.length
+  requestAnimationFrame(() => {
+    el.focus()
+    el.setSelectionRange(cursorPos, cursorPos)
+  })
+}
+
+function prefixLine(prefix: string) {
+  const el = textarea.value
+  if (!el) return
+  const start = el.selectionStart
+  const text = props.modelValue
+  // Find the start of the current line
+  const lineStart = text.lastIndexOf('\n', start - 1) + 1
+  const newText = text.slice(0, lineStart) + prefix + text.slice(lineStart)
+  emit('update:modelValue', newText)
+  const cursorPos = start + prefix.length
+  requestAnimationFrame(() => {
+    el.focus()
+    el.setSelectionRange(cursorPos, cursorPos)
+  })
+}
+
+function insertLink() {
+  const el = textarea.value
+  if (!el) return
+  const start = el.selectionStart
+  const end = el.selectionEnd
+  const text = props.modelValue
+  const selected = text.slice(start, end) || 'texte'
+  const insertion = `[${selected}](url)`
+  const newText = text.slice(0, start) + insertion + text.slice(end)
+  emit('update:modelValue', newText)
+  // Select "url" so user can type the actual URL
+  const urlStart = start + selected.length + 3
+  const urlEnd = urlStart + 3
+  requestAnimationFrame(() => {
+    el.focus()
+    el.setSelectionRange(urlStart, urlEnd)
+  })
+}
+
+function insertAtCursor(insertion: string) {
+  const el = textarea.value
+  if (!el) return
+  const start = el.selectionStart
+  const text = props.modelValue
+  const newText = text.slice(0, start) + insertion + text.slice(start)
+  emit('update:modelValue', newText)
+  const cursorPos = start + insertion.length
+  requestAnimationFrame(() => {
+    el.focus()
+    el.setSelectionRange(cursorPos, cursorPos)
+  })
+}
+
+// --- Image upload ---
+
+const fileInput = ref<HTMLInputElement | null>(null)
+
+function triggerImageUpload() {
+  fileInput.value?.click()
+}
+
+async function handleFileSelect(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (file) await handleImageFile(file)
+  input.value = ''
+}
+
+async function handleImageFile(file: File) {
+  const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png']
+  if (!allowedTypes.includes(file.type)) {
+    toast.error('Format accepté : JPG ou PNG uniquement')
+    return
+  }
+  if (file.size > 20 * 1024 * 1024) {
+    toast.error('La taille du fichier ne doit pas dépasser 20 Mo')
+    return
+  }
+
+  uploading.value = true
+  try {
+    const result = await uploadFile(file)
+    const markdown = `![${file.name}](/api/files/${result.uuid})`
+    insertAtCursor(markdown + '\n')
+    toast.success('Image uploadée')
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    uploading.value = false
+  }
+}
+
+// --- Drag & drop ---
+
+function onDragEnter(e: DragEvent) {
+  e.preventDefault()
+  if (e.dataTransfer?.types.includes('Files')) {
+    dragging.value = true
+  }
+}
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+}
+
+function onDragLeave(e: DragEvent) {
+  e.preventDefault()
+  // Only reset when leaving the container (not child elements)
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  const { clientX, clientY } = e
+  if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) {
+    dragging.value = false
+  }
+}
+
+async function onDrop(e: DragEvent) {
+  e.preventDefault()
+  dragging.value = false
+  const file = e.dataTransfer?.files?.[0]
+  if (file && file.type.startsWith('image/')) {
+    await handleImageFile(file)
+  }
+}
+
+// --- Paste images ---
+
+async function onPaste(e: ClipboardEvent) {
+  const items = e.clipboardData?.items
+  if (!items) return
+  for (const item of items) {
+    if (item.type.startsWith('image/')) {
+      e.preventDefault()
+      const file = item.getAsFile()
+      if (file) await handleImageFile(file)
+      return
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="border border-gray-300 rounded-md overflow-hidden">
+    <!-- Tabs + Toolbar -->
+    <div class="bg-gray-50 border-b border-gray-300">
+      <!-- Tabs -->
+      <div class="flex items-center border-b border-gray-200">
+        <button
+          type="button"
+          class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+          :class="activeTab === 'edit'
+            ? 'border-veaf-600 text-veaf-600'
+            : 'border-transparent text-gray-500 hover:text-gray-700'"
+          @click="activeTab = 'edit'"
+        >
+          Éditer
+        </button>
+        <button
+          type="button"
+          class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+          :class="activeTab === 'preview'
+            ? 'border-veaf-600 text-veaf-600'
+            : 'border-transparent text-gray-500 hover:text-gray-700'"
+          @click="activeTab = 'preview'"
+        >
+          Aperçu
+        </button>
+        <span v-if="uploading" class="ml-auto mr-3 text-xs text-gray-500">
+          <i class="fa-solid fa-spinner fa-spin mr-1"></i>Upload en cours...
+        </span>
+      </div>
+
+      <!-- Toolbar (only in edit mode) -->
+      <div v-if="activeTab === 'edit'" class="flex items-center gap-1 px-2 py-1.5">
+        <button
+          v-for="(btn, idx) in toolbarActions"
+          :key="idx"
+          type="button"
+          class="p-1.5 rounded hover:bg-gray-200 text-gray-600 hover:text-gray-900 transition-colors"
+          :title="btn.title"
+          @click="btn.action"
+        >
+          <i :class="[btn.icon, btn.size || 'text-sm']"></i>
+        </button>
+      </div>
+    </div>
+
+    <!-- Edit mode -->
+    <div
+      v-show="activeTab === 'edit'"
+      class="relative"
+      @dragenter="onDragEnter"
+      @dragover="onDragOver"
+      @dragleave="onDragLeave"
+      @drop="onDrop"
+    >
+      <textarea
+        ref="textarea"
+        :value="modelValue"
+        :rows="rows"
+        :placeholder="placeholder"
+        class="w-full px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-veaf-500 resize-y"
+        @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+        @paste="onPaste"
+      ></textarea>
+
+      <!-- Drag overlay -->
+      <div
+        v-if="dragging"
+        class="absolute inset-0 bg-veaf-50/80 border-2 border-dashed border-veaf-400 rounded flex items-center justify-center pointer-events-none"
+      >
+        <div class="text-veaf-600 font-medium">
+          <i class="fa-solid fa-cloud-arrow-up text-2xl mb-1 block text-center"></i>
+          Déposez l'image ici
+        </div>
+      </div>
+    </div>
+
+    <!-- Preview mode -->
+    <div
+      v-show="activeTab === 'preview'"
+      class="prose max-w-none px-3 py-2 min-h-[100px]"
+      :style="{ minHeight: `${rows * 1.5}rem` }"
+    >
+      <div v-if="modelValue" v-html="preview"></div>
+      <p v-else class="text-gray-400 italic text-sm">Aucun contenu à afficher.</p>
+    </div>
+
+    <!-- Hidden file input for image toolbar button -->
+    <input
+      ref="fileInput"
+      type="file"
+      accept="image/jpeg,image/png"
+      class="hidden"
+      @change="handleFileSelect"
+    />
+  </div>
+</template>

--- a/frontend/src/composables/useMarkdown.ts
+++ b/frontend/src/composables/useMarkdown.ts
@@ -1,0 +1,12 @@
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+marked.setOptions({
+  breaks: true,
+  gfm: true,
+})
+
+export function renderMarkdown(source: string): string {
+  const html = marked.parse(source, { async: false }) as string
+  return DOMPurify.sanitize(html)
+}

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/stores/auth'
 import { getEvent, voteEvent, deleteEvent, copyEvent } from '@/api/calendar'
 import type { EventDetail, Choice } from '@/types/calendar'
 import { useConfirm } from '@/composables/useConfirm'
+import { renderMarkdown } from '@/composables/useMarkdown'
 
 const route = useRoute()
 const router = useRouter()
@@ -196,11 +197,11 @@ function formatTime(d: string) {
 
       <!-- Contenu onglet -->
       <div v-if="activeTab === 'description'" class="prose max-w-none mb-6">
-        <p v-if="event.description" class="whitespace-pre-wrap">{{ event.description }}</p>
+        <div v-if="event.description" v-html="renderMarkdown(event.description)"></div>
         <p v-else class="text-gray-400 italic">Aucune description.</p>
       </div>
       <div v-else class="prose max-w-none mb-6">
-        <p v-if="event.debrief" class="whitespace-pre-wrap">{{ event.debrief }}</p>
+        <div v-if="event.debrief" v-html="renderMarkdown(event.debrief)"></div>
         <p v-else class="text-gray-400 italic">Aucun debrief.</p>
       </div>
 

--- a/frontend/src/views/EventEditView.vue
+++ b/frontend/src/views/EventEditView.vue
@@ -6,6 +6,7 @@ import { getModules } from '@/api/modules'
 import { getServers } from '@/api/servers'
 import { uploadFile } from '@/api/files'
 import { useToast } from '@/composables/useToast'
+import MarkdownEditor from '@/components/ui/MarkdownEditor.vue'
 import type { EventUpdate } from '@/types/calendar'
 import type { Module } from '@/types/module'
 import type { Server } from '@/types/api'
@@ -215,7 +216,7 @@ async function handleSubmit() {
       <!-- Description -->
       <div>
         <label class="label">Description</label>
-        <textarea v-model="form.description" class="input" rows="4" />
+        <MarkdownEditor :model-value="form.description ?? ''" @update:model-value="form.description = $event" />
       </div>
 
       <!-- Restrictions -->
@@ -281,7 +282,7 @@ async function handleSubmit() {
       <!-- Debrief (edit only) -->
       <div v-if="isEdit">
         <label class="label">Debrief</label>
-        <textarea v-model="form.debrief" class="input" rows="4" />
+        <MarkdownEditor :model-value="form.debrief ?? ''" @update:model-value="form.debrief = $event" />
       </div>
 
       <!-- Repeat -->

--- a/frontend/src/views/PageView.vue
+++ b/frontend/src/views/PageView.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { getPage } from '@/api/pages'
+import { renderMarkdown } from '@/composables/useMarkdown'
 import type { Page } from '@/types/api'
 
 const route = useRoute()
@@ -38,7 +39,7 @@ watch(() => route.params.slug, fetchPage)
   <div v-else-if="page" class="max-w-4xl mx-auto">
     <h1 class="text-3xl font-bold mb-6">{{ page.title }}</h1>
     <div v-for="block in page.blocks" :key="block.id" class="prose max-w-none mb-6">
-      <div v-if="block.type === 1" class="whitespace-pre-wrap">{{ block.content }}</div>
+      <div v-if="block.type === 1" v-html="renderMarkdown(block.content)"></div>
     </div>
   </div>
 </template>

--- a/frontend/src/views/admin/PageDetailView.vue
+++ b/frontend/src/views/admin/PageDetailView.vue
@@ -11,6 +11,7 @@ import {
 import type { Page, PageBlock } from '@/types/api'
 import { useConfirm } from '@/composables/useConfirm'
 import { useToast } from '@/composables/useToast'
+import MarkdownEditor from '@/components/ui/MarkdownEditor.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -297,12 +298,7 @@ onMounted(loadPage)
         <form class="space-y-4" @submit.prevent="handleBlockSubmit">
           <div>
             <label class="label">Contenu (Markdown)</label>
-            <textarea
-              v-model="blockForm.content"
-              class="input font-mono text-sm"
-              rows="15"
-              required
-            ></textarea>
+            <MarkdownEditor v-model="blockForm.content" :rows="15" />
           </div>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reusable Markdown editing and rendering workflow across pages and events, including secure HTML sanitization.

New Features:
- Add a MarkdownEditor component with toolbar, live preview, drag-and-drop/paste image upload, and file integration.
- Introduce a useMarkdown composable to render Markdown content into sanitized HTML for display in views.

Enhancements:
- Replace plain textareas in page and event admin forms with the Markdown editor for richer content authoring.
- Render event descriptions, debriefs, and page blocks as formatted Markdown instead of preformatted plain text.
- Correct the display title for the member restriction fixture from “Cadet” to “Member”.

Build:
- Add marked and dompurify (plus DOMPurify type definitions) as frontend dependencies for Markdown parsing and sanitization.