### PR TITLE
add breadcrumb

### DIFF
--- a/frontend/src/components/admin/AdminBreadcrumb.vue
+++ b/frontend/src/components/admin/AdminBreadcrumb.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+interface BreadcrumbItem {
+  label: string
+  to?: string
+  icon?: string
+}
+
+const props = defineProps<{
+  pageTitle?: string
+}>()
+
+const route = useRoute()
+
+const items = computed<BreadcrumbItem[]>(() => {
+  const meta = (route.meta.breadcrumb as BreadcrumbItem[] | undefined) ?? []
+  if (!meta.length) return []
+
+  const result = meta.map((item) => ({ ...item }))
+
+  if (props.pageTitle && result.length > 0) {
+    result[result.length - 1].label = props.pageTitle
+  }
+
+  return result
+})
+
+const lastItem = computed(() => items.value[items.value.length - 1] ?? null)
+</script>
+
+<template>
+  <div class="mb-6">
+    <nav v-if="items.length" class="flex items-center text-sm text-gray-500 mb-1">
+      <template v-for="(item, index) in items" :key="index">
+        <i v-if="index > 0" class="fa-solid fa-chevron-right mx-2 text-xs text-gray-400"></i>
+        <RouterLink
+          :to="{ name: item.to ?? route.name as string }"
+          class="transition-colors"
+          :class="index === items.length - 1 ? 'text-gray-700 hover:text-veaf-600' : 'hover:text-veaf-600'"
+        >
+          <i v-if="item.icon" :class="item.icon" class="mr-1"></i>{{ item.label }}
+        </RouterLink>
+      </template>
+    </nav>
+    <h1 v-if="lastItem" class="text-2xl font-bold">{{ lastItem.label }}</h1>
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -117,61 +117,132 @@ const router = createRouter({
       path: '/admin',
       name: 'admin',
       component: () => import('@/views/admin/DashboardView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Dashboard' },
+        ],
+      },
     },
     {
       path: '/admin/users',
       name: 'admin-users',
       component: () => import('@/views/admin/UsersView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Utilisateurs' },
+        ],
+      },
     },
     {
       path: '/admin/modules',
       name: 'admin-modules',
       component: () => import('@/views/admin/ModulesView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Modules' },
+        ],
+      },
     },
     {
       path: '/admin/calendar',
       name: 'admin-calendar',
       component: () => import('@/views/admin/CalendarAdminView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Calendrier' },
+        ],
+      },
     },
     {
       path: '/admin/pages',
       name: 'admin-pages',
       component: () => import('@/views/admin/PagesView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Pages' },
+        ],
+      },
     },
     {
       path: '/admin/pages/:id',
       name: 'admin-page-detail',
       component: () => import('@/views/admin/PageDetailView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Pages', to: 'admin-pages' },
+          { label: '' },
+        ],
+      },
     },
     {
       path: '/admin/files',
       name: 'admin-files',
       component: () => import('@/views/admin/FilesView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Fichiers' },
+        ],
+      },
     },
     {
       path: '/admin/servers',
       name: 'admin-servers',
       component: () => import('@/views/admin/ServersView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Serveurs' },
+        ],
+      },
     },
     {
       path: '/admin/urls',
       name: 'admin-urls',
       component: () => import('@/views/admin/UrlsView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'URLs' },
+        ],
+      },
     },
     {
       path: '/admin/menu',
       name: 'admin-menu',
       component: () => import('@/views/admin/MenuView.vue'),
-      meta: { requiresAuth: true, requiresAdmin: true },
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Menu' },
+        ],
+      },
     },
     // Redirect old /pages/ URLs
     {

--- a/frontend/src/views/admin/CalendarAdminView.vue
+++ b/frontend/src/views/admin/CalendarAdminView.vue
@@ -1,6 +1,10 @@
+<script setup lang="ts">
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
+</script>
+
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion du calendrier</h1>
+    <AdminBreadcrumb />
     <div class="card text-center py-12 text-gray-500">Administration du calendrier (Phase 4)</div>
   </div>
 </template>

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { getAdminStats, type AdminStats } from '@/api/admin'
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
 
 const stats = ref<AdminStats | null>(null)
 
@@ -15,7 +16,7 @@ onMounted(async () => {
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Administration</h1>
+    <AdminBreadcrumb />
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
       <RouterLink to="/admin/users" class="card text-center hover:shadow-md transition-shadow">
         <div class="text-veaf-400 mb-2"><i class="fa-solid fa-users text-2xl"></i></div>

--- a/frontend/src/views/admin/FilesView.vue
+++ b/frontend/src/views/admin/FilesView.vue
@@ -1,6 +1,10 @@
+<script setup lang="ts">
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
+</script>
+
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion des fichiers</h1>
+    <AdminBreadcrumb />
     <div class="card text-center py-12 text-gray-500">Administration des fichiers (Phase 4)</div>
   </div>
 </template>

--- a/frontend/src/views/admin/MenuView.vue
+++ b/frontend/src/views/admin/MenuView.vue
@@ -1,6 +1,10 @@
+<script setup lang="ts">
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
+</script>
+
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion du menu</h1>
+    <AdminBreadcrumb />
     <div class="card text-center py-12 text-gray-500">Administration du menu de navigation (Phase 4)</div>
   </div>
 </template>

--- a/frontend/src/views/admin/ModulesView.vue
+++ b/frontend/src/views/admin/ModulesView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
 import {
   getModules,
   getRoles,
@@ -324,7 +325,7 @@ onMounted(loadAll)
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion des modules</h1>
+    <AdminBreadcrumb />
 
     <!-- Tabs -->
     <div class="flex space-x-1 mb-6 border-b border-gray-200">

--- a/frontend/src/views/admin/PageDetailView.vue
+++ b/frontend/src/views/admin/PageDetailView.vue
@@ -12,6 +12,7 @@ import type { Page, PageBlock } from '@/types/api'
 import { useConfirm } from '@/composables/useConfirm'
 import { useToast } from '@/composables/useToast'
 import MarkdownEditor from '@/components/ui/MarkdownEditor.vue'
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -178,16 +179,11 @@ onMounted(loadPage)
 <template>
   <div>
     <!-- Header -->
-    <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold">{{ page?.title ?? 'Chargement...' }}</h1>
-      <div class="flex items-center space-x-3">
-        <a v-if="page" :href="'/' + page.path" target="_blank" class="btn-secondary" title="Ouvrir la page dans un nouvel onglet">
-          <i class="fa-solid fa-up-right-from-square mr-1"></i>Ouvrir la page
-        </a>
-        <button class="btn-secondary" @click="router.push({ name: 'admin-pages' })">
-          <i class="fa-solid fa-arrow-left mr-1"></i>Retour à la liste
-        </button>
-      </div>
+    <div class="flex items-start justify-between">
+      <AdminBreadcrumb :page-title="page?.title ?? 'Chargement...'" />
+      <a v-if="page" :href="'/' + page.path" target="_blank" class="btn-secondary mt-5" title="Ouvrir la page dans un nouvel onglet">
+        <i class="fa-solid fa-up-right-from-square mr-1"></i>Ouvrir la page
+      </a>
     </div>
 
     <div v-if="page">

--- a/frontend/src/views/admin/PagesView.vue
+++ b/frontend/src/views/admin/PagesView.vue
@@ -2,6 +2,7 @@
 import { ref, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { getAdminPages, createAdminPage, updateAdminPage, deleteAdminPage } from '@/api/pages'
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
 import type { Page } from '@/types/api'
 import { useConfirm } from '@/composables/useConfirm'
 import { useToast } from '@/composables/useToast'
@@ -208,7 +209,7 @@ onMounted(loadPages)
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion des pages</h1>
+    <AdminBreadcrumb />
 
     <!-- Search & Filters -->
     <div class="flex flex-wrap gap-4 mb-4">

--- a/frontend/src/views/admin/ServersView.vue
+++ b/frontend/src/views/admin/ServersView.vue
@@ -1,6 +1,10 @@
+<script setup lang="ts">
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
+</script>
+
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion des serveurs</h1>
+    <AdminBreadcrumb />
     <div class="card text-center py-12 text-gray-500">Administration des serveurs DCS (Phase 4)</div>
   </div>
 </template>

--- a/frontend/src/views/admin/UrlsView.vue
+++ b/frontend/src/views/admin/UrlsView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
 import { getAdminUrls, createAdminUrl, updateAdminUrl, deleteAdminUrl } from '@/api/urls'
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
 import type { Url } from '@/types/api'
 import { useConfirm } from '@/composables/useConfirm'
 import { useToast } from '@/composables/useToast'
@@ -144,7 +145,7 @@ onMounted(loadUrls)
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion des URLs</h1>
+    <AdminBreadcrumb />
 
     <!-- Search & Filters -->
     <div class="flex flex-wrap gap-4 mb-4">

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { getAdminUsers, updateAdminUser } from '@/api/users'
+import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
 import type { AdminUser, AdminUserUpdate } from '@/types/user'
 import { useToast } from '@/composables/useToast'
 
@@ -143,7 +144,7 @@ onMounted(loadUsers)
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-6">Gestion des utilisateurs</h1>
+    <AdminBreadcrumb />
 
     <!-- Search & Filter -->
     <div class="flex flex-col sm:flex-row gap-3 mb-4">


### PR DESCRIPTION
## Summary by Sourcery

Add a reusable admin breadcrumb component and wire it into admin routes and views to provide contextual navigation and page titles.

New Features:
- Introduce an AdminBreadcrumb component that builds breadcrumb navigation from route metadata and an optional dynamic page title.

Enhancements:
- Define breadcrumb metadata on all admin routes to drive consistent navigation hierarchy across the admin area.
- Replace hardcoded H1 headers in admin views with the shared AdminBreadcrumb component for unified layout and styling.