### PR TITLE
add admin servers

### DIFF
--- a/backend/app/api/admin_servers.py
+++ b/backend/app/api/admin_servers.py
@@ -1,0 +1,118 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import require_admin
+from app.database import get_db
+from app.models.dcs import Server
+from app.models.user import User
+from app.schemas.dcs import AdminServerListOut, ServerCreate, ServerOut, ServerUpdate
+
+router = APIRouter(prefix="/admin/servers", tags=["admin-servers"])
+
+
+@router.get("", response_model=AdminServerListOut)
+async def list_servers(
+    search: str | None = Query(None),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(Server)
+
+    if search:
+        pattern = f"%{search}%"
+        query = query.where(or_(Server.name.ilike(pattern), Server.code.ilike(pattern)))
+
+    count_query = select(func.count()).select_from(query.subquery())
+    total = (await db.execute(count_query)).scalar_one()
+
+    query = query.order_by(Server.name.asc()).offset(skip).limit(limit)
+    result = await db.execute(query)
+    servers = result.scalars().all()
+
+    return AdminServerListOut(
+        items=[ServerOut.model_validate(s) for s in servers],
+        total=total,
+    )
+
+
+@router.post("", response_model=ServerOut, status_code=status.HTTP_201_CREATED)
+async def create_server(
+    data: ServerCreate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    server = Server(
+        name=data.name,
+        code=data.code,
+    )
+
+    try:
+        db.add(server)
+        await db.commit()
+        await db.refresh(server)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Un serveur avec ce code existe déjà",
+        )
+
+    return ServerOut.model_validate(server)
+
+
+@router.get("/{server_id}", response_model=ServerOut)
+async def get_server(
+    server_id: int,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    server = await db.get(Server, server_id)
+    if server is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Serveur non trouvé")
+    return ServerOut.model_validate(server)
+
+
+@router.put("/{server_id}", response_model=ServerOut)
+async def update_server(
+    server_id: int,
+    data: ServerUpdate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    server = await db.get(Server, server_id)
+    if server is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Serveur non trouvé")
+
+    server.name = data.name
+    server.code = data.code
+
+    try:
+        await db.commit()
+        await db.refresh(server)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Un serveur avec ce code existe déjà",
+        )
+
+    return ServerOut.model_validate(server)
+
+
+@router.delete("/{server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_server(
+    server_id: int,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    server = await db.get(Server, server_id)
+    if server is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Serveur non trouvé")
+
+    await db.delete(server)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/admin_stats.py
+++ b/backend/app/api/admin_stats.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.dependencies import require_admin
 from app.database import get_db
 from app.models.content import MenuItem, Page, Url
+from app.models.dcs import Server
 from app.models.module import Module
 from app.models.user import User
 
@@ -18,6 +19,7 @@ class AdminStats(BaseModel):
     pages: int = 0
     urls: int = 0
     menu_items: int = 0
+    servers: int = 0
 
 
 @router.get("", response_model=AdminStats)
@@ -40,4 +42,7 @@ async def get_stats(
     result = await db.execute(select(func.count()).select_from(MenuItem))
     menu_items_count = result.scalar_one()
 
-    return AdminStats(modules=modules_count, users=users_count, pages=pages_count, urls=urls_count, menu_items=menu_items_count)
+    result = await db.execute(select(func.count()).select_from(Server))
+    servers_count = result.scalar_one()
+
+    return AdminStats(modules=modules_count, users=users_count, pages=pages_count, urls=urls_count, menu_items=menu_items_count, servers=servers_count)

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,12 +1,13 @@
 from fastapi import APIRouter
 
-from app.api import admin_menu, admin_modules, admin_pages, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, files, header, map, menu, metrics, mission_maker, modules, pages, recruitment, roster, servers, teamspeak, urls, users
+from app.api import admin_menu, admin_modules, admin_pages, admin_servers, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, files, header, map, menu, metrics, mission_maker, modules, pages, recruitment, roster, servers, teamspeak, urls, users
 
 api_router = APIRouter(prefix="/api")
 
 api_router.include_router(admin_menu.router)
 api_router.include_router(admin_modules.router)
 api_router.include_router(admin_pages.router)
+api_router.include_router(admin_servers.router)
 api_router.include_router(admin_stats.router)
 api_router.include_router(admin_urls.router)
 api_router.include_router(admin_users.router)

--- a/backend/app/models/dcs.py
+++ b/backend/app/models/dcs.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Boolean
+from sqlalchemy import DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -11,9 +11,7 @@ class Server(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(64), nullable=False)
-    code: Mapped[str] = mapped_column(String(64), nullable=False)
-    atc: Mapped[bool] = mapped_column(Boolean, default=False)
-    gci: Mapped[bool] = mapped_column(Boolean, default=False)
+    code: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
 
 
 class Player(Base):

--- a/backend/app/schemas/dcs.py
+++ b/backend/app/schemas/dcs.py
@@ -7,10 +7,23 @@ class ServerOut(BaseModel):
     id: int
     name: str
     code: str
-    atc: bool
-    gci: bool
 
     model_config = {"from_attributes": True}
+
+
+class ServerCreate(BaseModel):
+    name: str
+    code: str
+
+
+class ServerUpdate(BaseModel):
+    name: str
+    code: str
+
+
+class AdminServerListOut(BaseModel):
+    items: list[ServerOut]
+    total: int
 
 
 # --- DCSServerBot API response schemas ---

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -72,8 +72,6 @@ class ServerFactory(factory.Factory):
 
     name = factory.Sequence(lambda n: f"Server {n}")
     code = factory.Sequence(lambda n: f"srv{n}")
-    atc = False
-    gci = False
 
 
 class PageFactory(factory.Factory):

--- a/backend/tests/integration/api/test_admin_servers.py
+++ b/backend/tests/integration/api/test_admin_servers.py
@@ -1,0 +1,345 @@
+"""Integration tests for admin server CRUD endpoints."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import create_access_token
+from app.models.dcs import Server
+from tests.factories import AdminFactory, ServerFactory, UserFactory
+
+
+async def _create_admin(db: AsyncSession) -> tuple:
+    """Create an admin user and return (user, auth_headers)."""
+    user = AdminFactory.build()
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_user(db: AsyncSession) -> tuple:
+    """Create a regular user and return (user, auth_headers)."""
+    user = UserFactory.build()
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_server(db: AsyncSession, **overrides) -> Server:
+    """Create and return a server."""
+    server = ServerFactory.build(**overrides)
+    db.add(server)
+    await db.commit()
+    await db.refresh(server)
+    return server
+
+
+# =============================================================================
+# List servers — GET /api/admin/servers
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_servers_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_server(db_session, name="Alpha")
+    await _create_server(db_session, name="Bravo")
+
+    # WHEN
+    response = await client.get("/api/admin/servers", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    assert len(data["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_servers_search_by_name(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_server(db_session, name="Combat Server", code="combat")
+    await _create_server(db_session, name="Training Server", code="training")
+
+    # WHEN
+    response = await client.get("/api/admin/servers", params={"search": "combat"}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["name"] == "Combat Server"
+
+
+@pytest.mark.asyncio
+async def test_list_servers_search_by_code(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_server(db_session, name="Server A", code="srv-main")
+    await _create_server(db_session, name="Server B", code="srv-test")
+
+    # WHEN
+    response = await client.get("/api/admin/servers", params={"search": "main"}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["code"] == "srv-main"
+
+
+@pytest.mark.asyncio
+async def test_list_servers_pagination(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    for i in range(5):
+        await _create_server(db_session, name=f"Server {i}", code=f"srv-{i}")
+
+    # WHEN
+    response = await client.get("/api/admin/servers", params={"skip": 2, "limit": 2}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_servers_unauthenticated(client: AsyncClient):
+    # GIVEN - no auth headers
+
+    # WHEN
+    response = await client.get("/api/admin/servers")
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_servers_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.get("/api/admin/servers", headers=headers)
+
+    # THEN
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Create server — POST /api/admin/servers
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_server_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.post("/api/admin/servers", json={
+        "name": "Combat Server",
+        "code": "combat",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Combat Server"
+    assert data["code"] == "combat"
+    assert data["id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_server_defaults(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.post("/api/admin/servers", json={
+        "name": "Test Server",
+        "code": "test",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Test Server"
+    assert data["code"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_create_server_duplicate_code(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_server(db_session, code="existing")
+
+    # WHEN
+    response = await client.post("/api/admin/servers", json={
+        "name": "Another Server",
+        "code": "existing",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_server_unauthenticated(client: AsyncClient):
+    # GIVEN - no auth headers
+
+    # WHEN
+    response = await client.post("/api/admin/servers", json={
+        "name": "Nope",
+        "code": "nope",
+    })
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_server_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.post("/api/admin/servers", json={
+        "name": "Nope",
+        "code": "nope",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Get server — GET /api/admin/servers/{server_id}
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_server_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    server = await _create_server(db_session, name="Detail Server", code="detail")
+
+    # WHEN
+    response = await client.get(f"/api/admin/servers/{server.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == server.id
+    assert data["name"] == "Detail Server"
+    assert data["code"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_server_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.get("/api/admin/servers/9999", headers=headers)
+
+    # THEN
+    assert response.status_code == 404
+
+
+# =============================================================================
+# Update server — PUT /api/admin/servers/{server_id}
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_server_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    server = await _create_server(db_session, name="Old Name", code="old")
+
+    # WHEN
+    response = await client.put(f"/api/admin/servers/{server.id}", json={
+        "name": "New Name",
+        "code": "new",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "New Name"
+    assert data["code"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_update_server_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.put("/api/admin/servers/9999", json={
+        "name": "Nope",
+        "code": "nope",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_server_duplicate_code(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_server(db_session, code="taken")
+    server = await _create_server(db_session, code="mine")
+
+    # WHEN
+    response = await client.put(f"/api/admin/servers/{server.id}", json={
+        "name": server.name,
+        "code": "taken",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 409
+
+
+# =============================================================================
+# Delete server — DELETE /api/admin/servers/{server_id}
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_server_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    server = await _create_server(db_session)
+
+    # WHEN
+    response = await client.delete(f"/api/admin/servers/{server.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+
+    # Verify deletion
+    deleted = await db_session.get(Server, server.id)
+    assert deleted is None
+
+
+@pytest.mark.asyncio
+async def test_delete_server_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.delete("/api/admin/servers/9999", headers=headers)
+
+    # THEN
+    assert response.status_code == 404

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -6,6 +6,7 @@ export interface AdminStats {
   pages: number
   urls: number
   menu_items: number
+  servers: number
 }
 
 export async function getAdminStats(): Promise<AdminStats> {

--- a/frontend/src/api/servers.ts
+++ b/frontend/src/api/servers.ts
@@ -1,5 +1,5 @@
 import apiClient from './client'
-import type { Server, HeaderData, DcsBotPage, DcsBotServerDetailPage } from '@/types/api'
+import type { Server, ServerCreate, ServerUpdate, AdminServerListResponse, HeaderData, DcsBotPage, DcsBotServerDetailPage } from '@/types/api'
 
 export async function getServers(): Promise<Server[]> {
   const { data } = await apiClient.get<Server[]>('/servers')
@@ -19,4 +19,29 @@ export async function getDcsBotServers(): Promise<DcsBotPage> {
 export async function getDcsBotServer(serverName: string): Promise<DcsBotServerDetailPage> {
   const { data } = await apiClient.get<DcsBotServerDetailPage>(`/dcsbot/servers/${encodeURIComponent(serverName)}`)
   return data
+}
+
+// --- Admin ---
+
+export async function getAdminServers(params?: {
+  search?: string
+  skip?: number
+  limit?: number
+}): Promise<AdminServerListResponse> {
+  const { data } = await apiClient.get<AdminServerListResponse>('/admin/servers', { params })
+  return data
+}
+
+export async function createAdminServer(payload: ServerCreate): Promise<Server> {
+  const { data } = await apiClient.post<Server>('/admin/servers', payload)
+  return data
+}
+
+export async function updateAdminServer(serverId: number, payload: ServerUpdate): Promise<Server> {
+  const { data } = await apiClient.put<Server>(`/admin/servers/${serverId}`, payload)
+  return data
+}
+
+export async function deleteAdminServer(serverId: number): Promise<void> {
+  await apiClient.delete(`/admin/servers/${serverId}`)
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -157,8 +157,21 @@ export interface Server {
   id: number
   name: string
   code: string
-  atc: boolean
-  gci: boolean
+}
+
+export interface ServerCreate {
+  name: string
+  code: string
+}
+
+export interface ServerUpdate {
+  name: string
+  code: string
+}
+
+export interface AdminServerListResponse {
+  items: Server[]
+  total: number
 }
 
 // DCSServerBot types

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -205,7 +205,7 @@ function formatShortDate(d: string) {
             {{ event.type_as_string }} = {{ event.title }}
           </h1>
           <div class="mt-2 text-sm text-gray-600">
-            Le {{ formatDate(event.start_date) }} ê0 {{ formatTime(event.end_date) }}
+            Le {{ formatDate(event.start_date) }} à {{ formatTime(event.end_date) }}
             <span
               v-if="eventStatus"
               class="text-xs font-medium px-2 py-0.5 rounded-full ml-2"
@@ -213,7 +213,7 @@ function formatShortDate(d: string) {
             >
               {{ eventStatus.text }}
             </span>
-            <span v-if="event.repeat_event !== 0" class="ml-2 text-gray-400" title="\u00c9vénement récurrent">
+            <span v-if="event.repeat_event !== 0" class="ml-2 text-gray-400" title="événement récurrent">
               <i class="fa-solid fa-clock"></i>
             </span>
           </div>

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -45,7 +45,7 @@ onMounted(async () => {
       </RouterLink>
       <RouterLink to="/admin/servers" class="card text-center hover:shadow-md transition-shadow">
         <div class="text-veaf-400 mb-2"><i class="fa-solid fa-server text-2xl"></i></div>
-        <div class="text-3xl font-bold text-veaf-600 mb-2">-</div>
+        <div class="text-3xl font-bold text-veaf-600 mb-2">{{ stats?.servers ?? '-' }}</div>
         <div class="text-sm text-gray-600">Serveurs</div>
       </RouterLink>
       <RouterLink to="/admin/urls" class="card text-center hover:shadow-md transition-shadow">

--- a/frontend/src/views/admin/ServersView.vue
+++ b/frontend/src/views/admin/ServersView.vue
@@ -1,10 +1,250 @@
 <script setup lang="ts">
+import { ref, watch, onMounted } from 'vue'
+import { getAdminServers, createAdminServer, updateAdminServer, deleteAdminServer } from '@/api/servers'
 import AdminBreadcrumb from '@/components/admin/AdminBreadcrumb.vue'
+import type { Server } from '@/types/api'
+import { useConfirm } from '@/composables/useConfirm'
+import { useToast } from '@/composables/useToast'
+
+const { confirm } = useConfirm()
+const toast = useToast()
+
+// Data
+const servers = ref<Server[]>([])
+const total = ref(0)
+const loading = ref(false)
+
+// Search
+const searchInput = ref('')
+const search = ref('')
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+
+// Pagination
+const currentPage = ref(1)
+const pageSize = 50
+const totalPages = ref(1)
+
+// Form
+const showForm = ref(false)
+const editingServerId = ref<number | null>(null)
+const codeManuallyEdited = ref(false)
+const serverForm = ref({
+  name: '',
+  code: '',
+})
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function onNameInput() {
+  if (!codeManuallyEdited.value) {
+    serverForm.value.code = slugify(serverForm.value.name)
+  }
+}
+
+function onCodeInput() {
+  codeManuallyEdited.value = true
+}
+
+function onSearchInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  searchInput.value = value
+  if (searchTimeout) clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    search.value = value
+  }, 300)
+}
+
+async function loadServers() {
+  loading.value = true
+  try {
+    const params: Record<string, unknown> = {
+      skip: (currentPage.value - 1) * pageSize,
+      limit: pageSize,
+    }
+    if (search.value) params.search = search.value
+
+    const result = await getAdminServers(params as Parameters<typeof getAdminServers>[0])
+    servers.value = result.items
+    total.value = result.total
+    totalPages.value = Math.max(1, Math.ceil(result.total / pageSize))
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(search, () => {
+  currentPage.value = 1
+  loadServers()
+})
+
+function goToPage(page: number) {
+  currentPage.value = page
+  loadServers()
+}
+
+function openNew() {
+  editingServerId.value = null
+  codeManuallyEdited.value = false
+  serverForm.value = { name: '', code: '' }
+  showForm.value = true
+}
+
+function openEdit(s: Server) {
+  editingServerId.value = s.id
+  codeManuallyEdited.value = true
+  serverForm.value = {
+    name: s.name,
+    code: s.code,
+  }
+  showForm.value = true
+}
+
+async function handleSubmit() {
+  loading.value = true
+  try {
+    if (editingServerId.value) {
+      await updateAdminServer(editingServerId.value, serverForm.value)
+      toast.success('Serveur modifié avec succès')
+    } else {
+      await createAdminServer(serverForm.value)
+      toast.success('Serveur créé avec succès')
+    }
+    showForm.value = false
+    await loadServers()
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleDelete(s: Server) {
+  if (!(await confirm(`Supprimer le serveur "${s.name}" ?`))) return
+  loading.value = true
+  try {
+    await deleteAdminServer(s.id)
+    toast.success('Serveur supprimé avec succès')
+    await loadServers()
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadServers)
 </script>
 
 <template>
   <div>
     <AdminBreadcrumb />
-    <div class="card text-center py-12 text-gray-500">Administration des serveurs DCS (Phase 4)</div>
+
+    <!-- Search & Actions -->
+    <div class="flex flex-wrap gap-4 mb-4">
+      <div class="relative flex-1 min-w-[200px]">
+        <i class="fa-solid fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+        <input
+          :value="searchInput"
+          @input="onSearchInput"
+          type="text"
+          placeholder="Rechercher par nom ou code..."
+          class="input pl-9 w-full"
+        />
+      </div>
+      <button class="btn-primary" @click="openNew">
+        <i class="fa-solid fa-plus mr-1"></i>Ajouter un serveur
+      </button>
+    </div>
+
+    <!-- Server form -->
+    <div v-if="showForm" class="card mb-6">
+      <h3 class="text-lg font-semibold mb-4">
+        {{ editingServerId ? 'Modifier le serveur' : 'Ajouter un serveur' }}
+      </h3>
+      <form class="space-y-4" @submit.prevent="handleSubmit">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="label">Nom</label>
+            <input v-model="serverForm.name" @input="onNameInput" type="text" class="input" maxlength="64" required />
+            <p class="text-xs text-gray-500 mt-1">Nom d'affichage du serveur</p>
+          </div>
+          <div>
+            <label class="label">Code</label>
+            <input v-model="serverForm.code" @input="onCodeInput" type="text" class="input" maxlength="64" required />
+            <p class="text-xs text-gray-500 mt-1">Identifiant technique (auto-généré depuis le nom)</p>
+          </div>
+        </div>
+
+        <div class="flex justify-end space-x-3">
+          <button type="button" class="btn-secondary" @click="showForm = false">
+            <i class="fa-solid fa-xmark mr-1"></i>Annuler
+          </button>
+          <button type="submit" class="btn-primary" :disabled="loading">
+            <i class="fa-solid fa-floppy-disk mr-1"></i>{{ loading ? 'Enregistrement...' : editingServerId ? 'Modifier' : 'Créer' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Servers table -->
+    <div class="card overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b text-left">
+            <th class="p-2">Nom</th>
+            <th class="p-2">Code</th>
+            <th class="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="!servers.length">
+            <td colspan="3" class="p-4 text-center text-gray-500">Aucun serveur</td>
+          </tr>
+          <tr v-for="s in servers" :key="s.id" class="border-b hover:bg-gray-50">
+            <td class="p-2 font-medium">{{ s.name }}</td>
+            <td class="p-2 font-mono text-xs">{{ s.code }}</td>
+            <td class="p-2 space-x-3">
+              <button class="text-veaf-600 hover:text-veaf-800 text-sm" @click="openEdit(s)">
+                <i class="fa-solid fa-edit mr-1"></i>Modifier
+              </button>
+              <button class="text-red-600 hover:text-red-800 text-sm" @click="handleDelete(s)">
+                <i class="fa-solid fa-trash mr-1"></i>Supprimer
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="totalPages > 1" class="flex items-center justify-between mt-4">
+      <span class="text-sm text-gray-600">{{ total }} serveur(s) au total</span>
+      <div class="flex items-center space-x-2">
+        <button
+          class="btn-secondary text-sm"
+          :disabled="currentPage <= 1"
+          @click="goToPage(currentPage - 1)"
+        >
+          <i class="fa-solid fa-chevron-left mr-1"></i>Précédent
+        </button>
+        <span class="text-sm text-gray-600">Page {{ currentPage }} sur {{ totalPages }}</span>
+        <button
+          class="btn-secondary text-sm"
+          :disabled="currentPage >= totalPages"
+          @click="goToPage(currentPage + 1)"
+        >
+          Suivant<i class="fa-solid fa-chevron-right ml-1"></i>
+        </button>
+      </div>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary by Sourcery

Add full admin CRUD support for DCS servers, including backend API, persistence changes, and an admin UI with search and pagination.

New Features:
- Introduce admin-only REST endpoints to list, create, update, and delete servers with search and pagination support.
- Add an admin servers management page in the frontend with search, paginated listing, and create/edit/delete form handling.
- Expose the total number of servers in the admin dashboard statistics and display it in the admin UI.

Enhancements:
- Enforce uniqueness of server codes at the database level and simplify the server model and API payloads by removing unused ATC/GCI flags.
- Add typed client-side API helpers and shared ServerCreate/ServerUpdate/AdminServerListResponse types for admin server operations.
- Improve event detail text rendering with corrected French wording and tooltip casing.

Tests:
- Add comprehensive integration tests covering admin server list, search, pagination, create, read, update, delete, authorization, and conflict scenarios.