### PR TITLE
add cli to fix filenames

### DIFF
--- a/backend/app/commands/database.py
+++ b/backend/app/commands/database.py
@@ -2,7 +2,7 @@ import asyncio
 
 import typer
 
-database_app = typer.Typer(help="Database management commands")
+database_app = typer.Typer(help="Database management commands", no_args_is_help=True)
 
 
 async def _drop_tables() -> None:

--- a/backend/app/commands/maintenance.py
+++ b/backend/app/commands/maintenance.py
@@ -1,8 +1,12 @@
 import asyncio
+import os
 
 import typer
+from rich import print as rprint
 
-maintenance_app = typer.Typer(help="Maintenance commands")
+from app.config import settings
+
+maintenance_app = typer.Typer(help="Maintenance commands", no_args_is_help=True)
 
 
 async def _drop_tables() -> None:
@@ -41,3 +45,52 @@ async def _import_from_yaml(filepath: str) -> None:
     from app.commands.import_yaml import run_import
 
     await run_import(filepath)
+
+
+async def _fix_filenames(dry_run: bool) -> None:
+    from sqlalchemy import select
+
+    from app.database import AsyncSessionLocal, engine
+    from app.models.content import File
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(File.uuid, File.extension))
+        files = result.all()
+
+    await engine.dispose()
+
+    renamed = 0
+    already_ok = 0
+    missing = 0
+
+    for uuid, extension in files:
+        dir_path = os.path.join(settings.UPLOAD_DIR, uuid[0], uuid[1])
+        path_with_ext = os.path.join(dir_path, f"{uuid}.{extension}")
+        path_without_ext = os.path.join(dir_path, uuid)
+
+        if os.path.exists(path_with_ext):
+            already_ok += 1
+            continue
+
+        if os.path.exists(path_without_ext):
+            if dry_run:
+                rprint(f"  [bold cyan]\\[dry-run][/bold cyan] would rename {uuid} -> {uuid}.{extension}")
+            else:
+                os.rename(path_without_ext, path_with_ext)
+                rprint(f"  [bold green]\\[renamed][/bold green] {uuid} -> {uuid}.{extension}")
+            renamed += 1
+        else:
+            rprint(f"  [bold yellow]\\[missing][/bold yellow] file not found on disk for {uuid}")
+            missing += 1
+
+    rprint(f"\n[bold]Done.[/bold] already_ok=[green]{already_ok}[/green], renamed=[cyan]{renamed}[/cyan], missing=[yellow]{missing}[/yellow]")
+    if dry_run and renamed > 0:
+        rprint("[bold]Run with --no-dry-run to apply changes.[/bold]")
+
+
+@maintenance_app.command("fix-filenames")
+def fix_filenames(
+    dry_run: bool = typer.Option(True, help="Preview changes without renaming files"),
+) -> None:
+    """Rename uploaded files to add their extension (fixes legacy import)."""
+    asyncio.run(_fix_filenames(dry_run))

--- a/backend/uploads/.gitignore
+++ b/backend/uploads/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitkeep
+!.gitignore

--- a/backend/var/.gitignore
+++ b/backend/var/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitkeep
+!.gitignore

--- a/doc/migrate_from_legacy_website_v1.md
+++ b/doc/migrate_from_legacy_website_v1.md
@@ -1,0 +1,95 @@
+# Migration des données depuis l'ancien site
+
+Procédure pour importer les données de l'ancien site Symfony vers le nouveau site FastAPI + Vue.js.
+
+## Prérequis
+
+- Docker Compose lancé : `docker compose up`
+- Accès à phpMyAdmin sur l'ancien site
+- Accès au répertoire `var/data/files/` de l'ancien site (les fichiers uploadés)
+
+## Étape 1 — Exporter la base de données en YAML
+
+Depuis **phpMyAdmin** de l'ancien site :
+
+1. Sélectionner la base de données
+2. Aller dans l'onglet **Exporter**
+3. Choisir le format **YAML**
+4. **Exclure** les tables suivantes :
+   - `*_stats` (tables de statistiques)
+   - `pe_*` (tables Perun)
+5. Lancer l'export et récupérer le fichier `website.yml`
+
+## Étape 2 — Déposer le fichier YAML
+
+Copier le fichier exporté dans le répertoire `backend/var/` :
+
+```bash
+cp website.yml backend/var/website.yml
+```
+
+## Étape 3 — Copier les fichiers uploadés
+
+Les fichiers de l'ancien site sont stockés dans `var/data/files/` avec une arborescence `{uuid[0]}/{uuid[1]}/{uuid}` (sans extension).
+
+Créer une archive tar depuis l'ancien site, puis l'extraire dans le répertoire `uploads/` du backend :
+
+```bash
+# Sur l'ancien site : créer l'archive
+cd /var/www/html    # ou le répertoire racine de l'ancien site
+tar czf files.tgz -C var/data/files .
+
+# Copier l'archive vers le nouveau site
+cp files.tgz backend/var/files.tgz
+
+# Extraire dans le répertoire uploads du backend
+mkdir -p backend/uploads
+tar xzf backend/var/files.tgz -C backend/uploads
+```
+
+## Étape 4 — Importer les données en base
+
+Cette commande **supprime toutes les tables existantes**, les recrée, puis importe les données depuis le fichier YAML :
+
+```bash
+scripts/console.sh maintenance import-yaml
+```
+
+Le fichier `var/website.yml` est utilisé par défaut. Pour un autre chemin :
+
+```bash
+scripts/console.sh maintenance import-yaml --filepath var/autre_fichier.yml
+```
+
+## Étape 5 — Corriger les noms de fichiers
+
+Les fichiers importés depuis l'ancien site sont stockés sans extension (ex: `ab4680f3-...`), or le nouveau site attend `{uuid}.{extension}`. Cette commande renomme les fichiers en ajoutant leur extension depuis la base de données.
+
+Prévisualiser les changements (dry-run, par défaut) :
+
+```bash
+scripts/console.sh maintenance fix-filenames
+```
+
+Appliquer les renommages :
+
+```bash
+scripts/console.sh maintenance fix-filenames --no-dry-run
+```
+
+## Résumé des commandes
+
+```bash
+# 1. Démarrer les services
+docker compose up -d
+
+# 2. Déposer le YAML et les fichiers
+cp website.yml backend/var/website.yml
+tar xzf backend/var/files.tgz -C backend/uploads
+
+# 3. Importer les données
+scripts/console.sh maintenance import-yaml
+
+# 4. Corriger les noms de fichiers
+scripts/console.sh maintenance fix-filenames --no-dry-run
+```


### PR DESCRIPTION
## Summary by Sourcery

Add a maintenance CLI command and documentation to rename legacy-uploaded files to include their extensions during migration from the old website.

New Features:
- Introduce a `maintenance fix-filenames` CLI command with dry-run support to rename uploaded files based on database metadata.
- Enable Typer maintenance and database command groups to show help when invoked without subcommands.

Documentation:
- Add a migration guide documenting the end-to-end process for importing data and files from the legacy Symfony website, including the new filename-fixing command.

Chores:
- Add placeholder .gitignore files for backend upload and var directories to manage repository contents.