### PR TITLE
add need introduction on cadets in roster view

### DIFF
--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -5,6 +5,7 @@ class RosterStatsOut(BaseModel):
     all: int
     cadets: int
     members: int
+    cadets_need_presentation: int = 0
 
 
 class RosterUserOut(BaseModel):
@@ -13,6 +14,7 @@ class RosterUserOut(BaseModel):
     status: int
     status_as_string: str | None = None
     active_module_count: int = 0
+    need_presentation: bool = False
 
 
 class RosterModuleOut(BaseModel):

--- a/frontend/src/api/roster.ts
+++ b/frontend/src/api/roster.ts
@@ -6,6 +6,7 @@ export interface RosterStats {
   all: number
   cadets: number
   members: number
+  cadets_need_presentation: number
 }
 
 export interface RosterUser {
@@ -14,6 +15,7 @@ export interface RosterUser {
   status: number
   status_as_string: string | null
   active_module_count: number
+  need_presentation: boolean
 }
 
 export interface RosterModule {

--- a/frontend/src/components/roster/RosterPilotsList.vue
+++ b/frontend/src/components/roster/RosterPilotsList.vue
@@ -4,12 +4,14 @@ import { RouterLink } from 'vue-router'
 import { getRosterPilots } from '@/api/roster'
 import type { RosterUser } from '@/api/roster'
 import { useRosterHelpers } from '@/composables/useRosterHelpers'
+import { useAuthStore } from '@/stores/auth'
 
 const props = defineProps<{
   group: string
 }>()
 
 const { statusIcon } = useRosterHelpers()
+const authStore = useAuthStore()
 
 const users = ref<RosterUser[]>([])
 const loading = ref(true)
@@ -45,6 +47,13 @@ watch(() => props.group, fetchPilots, { immediate: true })
             >
               {{ u.nickname }}
             </RouterLink>
+            <span
+              v-if="authStore.isMember && u.need_presentation"
+              class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs bg-yellow-100 text-yellow-700"
+              title="Ce pilote a besoin d'une présentation de l'association"
+            >
+              <i class="fa-solid fa-bullhorn"></i>
+            </span>
           </td>
           <td class="py-2 px-3 text-right">
             <span

--- a/frontend/src/views/RosterView.vue
+++ b/frontend/src/views/RosterView.vue
@@ -6,11 +6,14 @@ import RosterPilotsList from '@/components/roster/RosterPilotsList.vue'
 import RosterModuleList from '@/components/roster/RosterModuleList.vue'
 import RosterModuleDetail from '@/components/roster/RosterModuleDetail.vue'
 import { TAB_TO_MODULE_TYPE } from '@/constants/modules'
+import { useAuthStore } from '@/stores/auth'
+
+const authStore = useAuthStore()
 
 const group = ref('all')
 const tab = ref('pilots')
 const selectedModuleId = ref<number | null>(null)
-const stats = ref<RosterStats>({ all: 0, cadets: 0, members: 0 })
+const stats = ref<RosterStats>({ all: 0, cadets: 0, members: 0, cadets_need_presentation: 0 })
 const loading = ref(true)
 
 const groups = [
@@ -93,6 +96,20 @@ onMounted(async () => {
           <span class="hidden xl:inline">{{ t.label }}</span>
         </button>
       </div>
+    </div>
+
+    <!-- Alert: cadets needing presentation -->
+    <div
+      v-if="authStore.isMember && stats.cadets_need_presentation > 0"
+      class="mb-6 rounded-lg bg-yellow-50 border border-yellow-200 px-4 py-3 text-sm text-yellow-800"
+    >
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-200 text-yellow-900 mr-2">
+        {{ stats.cadets_need_presentation }}
+      </span>
+      <i class="fa-solid fa-user-graduate text-yellow-500 mr-1"></i>
+      cadet(s) n'ont pas encore eu la
+      <i class="fa-solid fa-bullhorn text-yellow-500 mx-1"></i>
+      présentation de l'association
     </div>
 
     <!-- Content area -->


### PR DESCRIPTION
## Summary by Sourcery

Expose and display which cadet pilots still need an association presentation in the roster view.

New Features:
- Add backend and API support to count cadets needing an association presentation and expose this in roster stats.
- Add a per-pilot flag in the roster API and UI indicating that a cadet needs an association presentation.
- Show a member-only alert in the roster view summarizing how many cadets still need an association presentation.