### PR TITLE
notify when cadets are ready to rejoin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,128 @@ VEAF Website 2026 — community web app for the Virtual European Air Force (DCS 
 - **Frontend**: Vue 3 (Composition API) + TypeScript + Vite 6 + Tailwind CSS 3 + Pinia stores
 - **Infra**: Docker Compose, Nginx reverse proxy, single uvicorn worker (for in-memory cache consistency)
 
+## Project Tree
+
+```
+.
+├── CLAUDE.md                          # Instructions for Claude Code
+├── README.md
+├── docker-compose.yml                 # 4 services: backend, frontend, nginx, postgres
+├── backend/
+│   ├── Dockerfile
+│   ├── entrypoint.sh                  # Container entrypoint (migrations auto-run)
+│   ├── pyproject.toml / uv.lock       # Python dependencies (uv)
+│   ├── alembic.ini
+│   ├── alembic/
+│   │   └── versions/                  # Migration files
+│   ├── app/
+│   │   ├── main.py                    # FastAPI entry point
+│   │   ├── config.py                  # Pydantic Settings (env vars)
+│   │   ├── database.py                # Async engine, session, get_db()
+│   │   ├── console.py                 # CLI entry point (Typer)
+│   │   ├── dependencies.py            # Shared FastAPI dependencies
+│   │   ├── api/                       # Route handlers (/api prefix)
+│   │   │   ├── router.py              # Mounts all routes
+│   │   │   ├── auth.py                # Login, register, refresh, password reset
+│   │   │   ├── users.py, calendar.py, modules.py, pages.py, servers.py, ...
+│   │   │   ├── admin_users.py, admin_events.py, admin_modules.py, ...
+│   │   │   └── admin/                 # (sub-package, currently empty)
+│   │   ├── auth/                      # Auth layer
+│   │   │   ├── jwt.py                 # Token creation/validation
+│   │   │   ├── password.py            # Hashing (bcrypt)
+│   │   │   ├── dependencies.py        # get_current_user, require_admin, ...
+│   │   │   └── permissions.py         # Voter-pattern permission checks
+│   │   ├── models/                    # SQLAlchemy 2.0 ORM models
+│   │   │   ├── user.py               # User, UserModule
+│   │   │   ├── module.py             # Module, ModuleRole, ModuleSystem
+│   │   │   ├── calendar.py           # CalendarEvent, Flight, Slot, Choice, Vote, Notification
+│   │   │   ├── content.py            # Page, PageBlock, MenuItem, Url, File
+│   │   │   ├── dcs.py                # Server, Player, DcsBotSyncState
+│   │   │   └── recruitment.py        # RecruitmentEvent
+│   │   ├── schemas/                   # Pydantic v2 DTOs
+│   │   │   ├── auth.py, user.py, calendar.py, content.py, dcs.py, ...
+│   │   │   └── header.py, module.py, roster.py, teamspeak.py
+│   │   ├── services/                  # Business logic
+│   │   │   ├── dcsbot.py             # DCS bot integration
+│   │   │   ├── teamspeak.py          # TeamSpeak queries
+│   │   │   └── sun_position.py       # Sun position calculations
+│   │   ├── commands/                  # CLI commands (Typer)
+│   │   │   ├── database.py           # create, fixtures
+│   │   │   ├── import_yaml.py        # YAML data import
+│   │   │   └── maintenance.py        # Maintenance tasks
+│   │   ├── tasks/                     # Background tasks
+│   │   │   ├── scheduler.py          # Task scheduler
+│   │   │   └── teamspeak_scan.py     # Periodic TS scan
+│   │   └── utils/
+│   │       └── cache.py              # In-memory TTLCache
+│   ├── fixtures/                      # YAML seed data
+│   │   ├── users.py, modules.py, calendar.py, content.py, ...
+│   │   └── reference.py, user_modules.py
+│   ├── tests/
+│   │   ├── conftest.py               # Pytest fixtures (SQLite in-memory DB)
+│   │   ├── factories.py              # factory-boy model factories
+│   │   ├── unit/                     # Unit tests
+│   │   │   ├── test_permissions.py, test_sun_position.py, test_user_model.py
+│   │   │   └── services/test_teamspeak.py
+│   │   ├── integration/api/          # Integration tests (HTTP)
+│   │   │   ├── test_auth.py, test_admin_users.py, test_admin_events.py, ...
+│   │   │   └── test_calendar_events.py, test_teamspeak.py, ...
+│   │   └── functional/              # Functional tests (empty for now)
+│   ├── uploads/                      # User-uploaded files
+│   └── var/                          # Runtime data (logs, etc.)
+├── frontend/
+│   ├── Dockerfile
+│   ├── nginx.conf                    # Production Nginx config
+│   ├── package.json / package-lock.json
+│   ├── vite.config.ts                # Vite config (@ alias, proxy)
+│   ├── tailwind.config.js            # Tailwind + veaf-* palette
+│   ├── tsconfig.json
+│   ├── index.html                    # SPA entry HTML
+│   ├── public/                       # Static assets (images, favicon)
+│   └── src/
+│       ├── main.ts                   # Vue app bootstrap (Pinia, Router, FA icons)
+│       ├── App.vue                   # Root component (ConfirmModal mounted here)
+│       ├── config.ts                 # Runtime config
+│       ├── api/                      # Axios API clients
+│       │   ├── client.ts             # Base Axios instance (JWT injection, 401 refresh)
+│       │   ├── auth.ts, admin.ts, users.ts, calendar.ts, modules.ts, ...
+│       │   └── pages.ts, servers.ts, files.ts, urls.ts, recruitment.ts, roster.ts
+│       ├── stores/                   # Pinia stores (Composition API)
+│       │   ├── auth.ts, calendar.ts, menu.ts, header.ts
+│       ├── composables/              # Vue composables
+│       │   ├── useConfirm.ts, useToast.ts, useMarkdown.ts, useRosterHelpers.ts
+│       ├── components/
+│       │   ├── layout/               # AppHeader, AppFooter, NavMenu
+│       │   ├── ui/                   # Shared: ConfirmModal, ChoiceModal, MarkdownEditor, ...
+│       │   ├── home/                 # HeroBanner, ModuleCard
+│       │   ├── admin/                # MenuTreeView, MenuTreeNode, MenuListView
+│       │   ├── roster/               # RosterModuleList, RosterModuleDetail, RosterPilotsList
+│       │   └── recruitment/          # AddActivityModal
+│       ├── views/                    # Page-level components
+│       │   ├── HomeView, LoginView, RegisterView, CalendarView, ...
+│       │   ├── RosterView, ServersView, MapView, MetricsView, ...
+│       │   └── admin/                # DashboardView, UsersView, ModulesView, PagesView, ...
+│       ├── router/                   # Vue Router (index.ts)
+│       ├── types/                    # TypeScript interfaces
+│       │   ├── api.ts, user.ts, calendar.ts, module.ts, teamspeak.ts
+│       ├── constants/                # Shared constants (modules.ts)
+│       ├── utils/                    # Utilities (format.ts)
+│       └── assets/css/               # Tailwind layers + custom components
+├── nginx/
+│   └── default.conf                  # Dev reverse proxy config
+├── scripts/                          # Docker helper scripts
+│   ├── alembic.sh, console.sh, python.sh, uv.sh, npm.sh
+│   ├── start.sh, stop.sh, build.sh, upgrade.sh
+│   └── dev/
+│       ├── fixtures.sh               # Migrations + seed data
+│       ├── test.sh                   # Run backend tests
+│       └── convert-webp.sh           # Image conversion
+├── doc/                              # Documentation
+│   └── migrate_from_legacy_website_v1.md
+└── plans/                            # Implementation plans
+    └── refonte_python.md
+```
+
 ## Common Commands
 
 ### Docker (primary development method)

--- a/backend/app/api/admin_stats.py
+++ b/backend/app/api/admin_stats.py
@@ -22,6 +22,7 @@ class AdminStats(BaseModel):
     urls: int = 0
     menu_items: int = 0
     servers: int = 0
+    cadets_ready_to_promote: int = 0
 
 
 @router.get("", response_model=AdminStats)
@@ -50,4 +51,25 @@ async def get_stats(
     result = await db.execute(select(func.count()).select_from(Server))
     servers_count = result.scalar_one()
 
-    return AdminStats(modules=modules_count, users=users_count, events=events_count, pages=pages_count, urls=urls_count, menu_items=menu_items_count, servers=servers_count)
+    result = await db.execute(
+        select(func.count())
+        .select_from(User)
+        .where(
+            User.status == User.STATUS_CADET,
+            User.sim_dcs.is_(True),
+            User.need_presentation.is_(False),
+            User.cadet_flights >= User.CADET_MIN_FLIGHTS,
+        )
+    )
+    cadets_ready_count = result.scalar_one()
+
+    return AdminStats(
+        modules=modules_count,
+        users=users_count,
+        events=events_count,
+        pages=pages_count,
+        urls=urls_count,
+        menu_items=menu_items_count,
+        servers=servers_count,
+        cadets_ready_to_promote=cadets_ready_count,
+    )

--- a/backend/app/api/admin_users.py
+++ b/backend/app/api/admin_users.py
@@ -28,6 +28,7 @@ def _build_admin_user_out(user: User) -> AdminUserOut:
         forum=user.forum,
         need_presentation=user.need_presentation,
         cadet_flights=user.cadet_flights,
+        is_ready_to_promote=user.is_ready_to_promote,
         created_at=user.created_at,
         updated_at=user.updated_at,
     )

--- a/backend/app/api/roster.py
+++ b/backend/app/api/roster.py
@@ -39,11 +39,22 @@ async def get_roster_stats(db: AsyncSession = Depends(get_db)):
         .select_from(User)
         .where(User.status == User.STATUS_CADET, User.need_presentation.is_(True))
     )
+    cadets_ready = await db.scalar(
+        select(func.count())
+        .select_from(User)
+        .where(
+            User.status == User.STATUS_CADET,
+            User.sim_dcs.is_(True),
+            User.need_presentation.is_(False),
+            User.cadet_flights >= User.CADET_MIN_FLIGHTS,
+        )
+    )
     return RosterStatsOut(
         all=all_count or 0,
         cadets=cadets_count or 0,
         members=members_count or 0,
         cadets_need_presentation=cadets_need_presentation or 0,
+        cadets_ready_to_promote=cadets_ready or 0,
     )
 
 
@@ -69,6 +80,7 @@ async def get_roster_pilots(group: str = "all", db: AsyncSession = Depends(get_d
             status_as_string=u.status_as_string,
             active_module_count=count or 0,
             need_presentation=u.need_presentation,
+            is_ready_to_promote=u.is_ready_to_promote,
         )
         for u, count in result.all()
     ]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -111,6 +111,15 @@ class User(Base):
         return self.STATUSES.get(self.status, "inconnu")
 
     @property
+    def is_ready_to_promote(self) -> bool:
+        return (
+            self.status == self.STATUS_CADET
+            and self.sim_dcs
+            and not self.need_presentation
+            and self.cadet_flights >= self.CADET_MIN_FLIGHTS
+        )
+
+    @property
     def recruitment_status(self) -> str:
         if self.status == self.STATUS_CADET:
             return "cadet"

--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -6,6 +6,7 @@ class RosterStatsOut(BaseModel):
     cadets: int
     members: int
     cadets_need_presentation: int = 0
+    cadets_ready_to_promote: int = 0
 
 
 class RosterUserOut(BaseModel):
@@ -15,6 +16,7 @@ class RosterUserOut(BaseModel):
     status_as_string: str | None = None
     active_module_count: int = 0
     need_presentation: bool = False
+    is_ready_to_promote: bool = False
 
 
 class RosterModuleOut(BaseModel):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -90,6 +90,7 @@ class AdminUserOut(BaseModel):
     forum: str | None = None
     need_presentation: bool
     cadet_flights: int
+    is_ready_to_promote: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/fixtures/users.py
+++ b/backend/fixtures/users.py
@@ -15,6 +15,7 @@ USERS_DATA = [
     {"key": "cadet", "email": "cadet@localhost.dev", "nickname": "cadet", "roles": "ROLE_USER,ROLE_CADET", "status": User.STATUS_CADET, "sim_dcs": True, "sim_bms": False},
     {"key": "cadet_need_presentation", "email": "cadet_need_presentation@localhost.dev", "nickname": "cadet_need_presentation", "roles": "ROLE_USER,ROLE_CADET", "status": User.STATUS_CADET, "sim_dcs": True, "sim_bms": False, "need_presentation": True},
     {"key": "cadet_with_presentation", "email": "cadet_with_presentation@localhost.dev", "nickname": "cadet_with_presentation", "roles": "ROLE_USER,ROLE_CADET", "status": User.STATUS_CADET, "sim_dcs": True, "sim_bms": False},
+    {"key": "cadet_ready", "email": "cadet_ready@localhost.dev", "nickname": "cadet_ready", "roles": "ROLE_USER,ROLE_CADET", "status": User.STATUS_CADET, "sim_dcs": True, "sim_bms": False, "need_presentation": False, "cadet_flights": 5},
     {"key": "membre", "email": "membre@localhost.dev", "nickname": "membre", "roles": "ROLE_USER", "status": User.STATUS_MEMBER, "sim_dcs": True, "sim_bms": False},
     {"key": "tresorier_adjoint", "email": "tresorier-adjoint@localhost.dev", "nickname": "trésorier adjoint", "roles": "ROLE_USER", "status": User.STATUS_TREASURER_DEPUTY, "sim_dcs": True, "sim_bms": False},
     {"key": "tresorier", "email": "tresorier@localhost.dev", "nickname": "trésorier", "roles": "ROLE_USER", "status": User.STATUS_TREASURER, "sim_dcs": True, "sim_bms": False},
@@ -45,6 +46,7 @@ async def load_users(session: AsyncSession) -> dict[str, User]:
             sim_dcs=item["sim_dcs"],
             sim_bms=item["sim_bms"],
             need_presentation=item.get("need_presentation", False),
+            cadet_flights=item.get("cadet_flights", 0),
             created_at=now,
             updated_at=now,
         )

--- a/backend/tests/integration/api/test_admin_stats.py
+++ b/backend/tests/integration/api/test_admin_stats.py
@@ -1,0 +1,55 @@
+"""Integration tests for admin stats endpoint."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import create_access_token
+from app.models.user import User
+from tests.factories import AdminFactory, UserFactory
+
+
+async def _create_admin(db: AsyncSession) -> tuple:
+    """Create an admin user and return (user, auth_headers)."""
+    user = AdminFactory.build()
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_stats_includes_cadets_ready_to_promote(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    ready_cadet = UserFactory.build(
+        status=User.STATUS_CADET, sim_dcs=True, need_presentation=False, cadet_flights=5,
+    )
+    not_ready_cadet = UserFactory.build(
+        status=User.STATUS_CADET, sim_dcs=False, need_presentation=True, cadet_flights=2,
+    )
+    db_session.add_all([ready_cadet, not_ready_cadet])
+    await db_session.commit()
+
+    # WHEN
+    response = await client.get("/api/admin/stats", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cadets_ready_to_promote"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stats_cadets_ready_zero_when_none(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.get("/api/admin/stats", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cadets_ready_to_promote"] == 0

--- a/backend/tests/integration/api/test_admin_users.py
+++ b/backend/tests/integration/api/test_admin_users.py
@@ -100,6 +100,32 @@ async def test_list_users_search_by_email(client: AsyncClient, db_session: Async
 
 
 @pytest.mark.asyncio
+async def test_list_users_includes_is_ready_to_promote(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    ready_cadet = UserFactory.build(
+        status=User.STATUS_CADET, sim_dcs=True, need_presentation=False, cadet_flights=5,
+    )
+    not_ready_cadet = UserFactory.build(
+        status=User.STATUS_CADET, sim_dcs=True, need_presentation=True, cadet_flights=3,
+    )
+    db_session.add_all([ready_cadet, not_ready_cadet])
+    await db_session.commit()
+    await db_session.refresh(ready_cadet)
+    await db_session.refresh(not_ready_cadet)
+
+    # WHEN
+    response = await client.get(f"/api/admin/users?status={User.STATUS_CADET}", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    items_by_id = {item["id"]: item for item in data["items"]}
+    assert items_by_id[ready_cadet.id]["is_ready_to_promote"] is True
+    assert items_by_id[not_ready_cadet.id]["is_ready_to_promote"] is False
+
+
+@pytest.mark.asyncio
 async def test_list_users_status_filter(client: AsyncClient, db_session: AsyncSession):
     # GIVEN
     _, headers = await _create_admin(db_session)

--- a/backend/tests/unit/test_user_model.py
+++ b/backend/tests/unit/test_user_model.py
@@ -1,0 +1,58 @@
+"""Unit tests for User model properties."""
+
+from app.models.user import User
+
+
+def test_is_ready_to_promote_all_conditions_met():
+    # GIVEN
+    user = User(
+        email="test@veaf.org", nickname="test", password="x",
+        status=User.STATUS_CADET, sim_dcs=True, need_presentation=False, cadet_flights=5,
+    )
+
+    # THEN
+    assert user.is_ready_to_promote is True
+
+
+def test_is_ready_to_promote_not_cadet():
+    # GIVEN
+    user = User(
+        email="test@veaf.org", nickname="test", password="x",
+        status=User.STATUS_MEMBER, sim_dcs=True, need_presentation=False, cadet_flights=5,
+    )
+
+    # THEN
+    assert user.is_ready_to_promote is False
+
+
+def test_is_ready_to_promote_no_dcs():
+    # GIVEN
+    user = User(
+        email="test@veaf.org", nickname="test", password="x",
+        status=User.STATUS_CADET, sim_dcs=False, need_presentation=False, cadet_flights=5,
+    )
+
+    # THEN
+    assert user.is_ready_to_promote is False
+
+
+def test_is_ready_to_promote_needs_presentation():
+    # GIVEN
+    user = User(
+        email="test@veaf.org", nickname="test", password="x",
+        status=User.STATUS_CADET, sim_dcs=True, need_presentation=True, cadet_flights=5,
+    )
+
+    # THEN
+    assert user.is_ready_to_promote is False
+
+
+def test_is_ready_to_promote_not_enough_flights():
+    # GIVEN
+    user = User(
+        email="test@veaf.org", nickname="test", password="x",
+        status=User.STATUS_CADET, sim_dcs=True, need_presentation=False, cadet_flights=4,
+    )
+
+    # THEN
+    assert user.is_ready_to_promote is False

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -8,6 +8,7 @@ export interface AdminStats {
   urls: number
   menu_items: number
   servers: number
+  cadets_ready_to_promote: number
 }
 
 export async function getAdminStats(): Promise<AdminStats> {

--- a/frontend/src/api/roster.ts
+++ b/frontend/src/api/roster.ts
@@ -7,6 +7,7 @@ export interface RosterStats {
   cadets: number
   members: number
   cadets_need_presentation: number
+  cadets_ready_to_promote: number
 }
 
 export interface RosterUser {
@@ -16,6 +17,7 @@ export interface RosterUser {
   status_as_string: string | null
   active_module_count: number
   need_presentation: boolean
+  is_ready_to_promote: boolean
 }
 
 export interface RosterModule {

--- a/frontend/src/components/roster/RosterPilotsList.vue
+++ b/frontend/src/components/roster/RosterPilotsList.vue
@@ -48,6 +48,13 @@ watch(() => props.group, fetchPilots, { immediate: true })
               {{ u.nickname }}
             </RouterLink>
             <span
+              v-if="authStore.isMember && u.is_ready_to_promote"
+              class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs bg-green-100 text-green-700"
+              title="Prêt à rejoindre l'association"
+            >
+              <i class="fa-solid fa-circle-check"></i>
+            </span>
+            <span
               v-if="authStore.isMember && u.need_presentation"
               class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs bg-yellow-100 text-yellow-700"
               title="Ce pilote a besoin d'une présentation de l'association"

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -69,6 +69,7 @@ export interface AdminUser {
   forum: string | null
   need_presentation: boolean
   cadet_flights: number
+  is_ready_to_promote: boolean
   created_at: string | null
   updated_at: string | null
 }

--- a/frontend/src/views/RosterView.vue
+++ b/frontend/src/views/RosterView.vue
@@ -14,7 +14,7 @@ const authStore = useAuthStore()
 const group = ref('all')
 const tab = ref('pilots')
 const selectedModuleId = ref<number | null>(null)
-const stats = ref<RosterStats>({ all: 0, cadets: 0, members: 0, cadets_need_presentation: 0 })
+const stats = ref<RosterStats>({ all: 0, cadets: 0, members: 0, cadets_need_presentation: 0, cadets_ready_to_promote: 0 })
 const loading = ref(true)
 
 const groups = [
@@ -111,6 +111,19 @@ onMounted(async () => {
       cadet(s) n'ont pas encore eu la
       <i class="fa-solid fa-bullhorn text-yellow-500 mx-1"></i>
       présentation de l'association
+    </div>
+
+    <!-- Alert: cadets ready to promote -->
+    <div
+      v-if="authStore.isMember && stats.cadets_ready_to_promote > 0"
+      class="mb-6 rounded-lg bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-800"
+    >
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-200 text-green-900 mr-2">
+        {{ stats.cadets_ready_to_promote }}
+      </span>
+      <i class="fa-solid fa-circle-check text-green-600 mr-1"></i>
+      cadet{{ stats.cadets_ready_to_promote > 1 ? 's' : '' }}
+      prêt{{ stats.cadets_ready_to_promote > 1 ? 's' : '' }} à rejoindre l'association
     </div>
 
     <!-- Content area -->

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -17,6 +17,22 @@ onMounted(async () => {
 <template>
   <div>
     <AppBreadcrumb :show-title="false" />
+    <!-- Cadet readiness notification -->
+    <RouterLink
+      v-if="stats?.cadets_ready_to_promote"
+      to="/admin/users?status=1"
+      class="card mb-4 flex items-center gap-3 hover:shadow-md transition-shadow border-green-200 bg-green-50"
+    >
+      <div class="text-green-600"><i class="fa-solid fa-circle-check text-2xl"></i></div>
+      <div>
+        <span class="text-lg font-bold text-green-700">{{ stats.cadets_ready_to_promote }}</span>
+        <span class="text-sm text-green-800 ml-1">
+          cadet{{ stats.cadets_ready_to_promote > 1 ? 's' : '' }}
+          prêt{{ stats.cadets_ready_to_promote > 1 ? 's' : '' }} à rejoindre l'association
+        </span>
+      </div>
+    </RouterLink>
+
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
       <RouterLink to="/admin/users" class="card text-center hover:shadow-md transition-shadow">
         <div class="text-veaf-400 mb-2"><i class="fa-solid fa-users text-2xl"></i></div>

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -1,21 +1,27 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { getAdminUsers, updateAdminUser } from '@/api/users'
+import { getAdminStats } from '@/api/admin'
 import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
 import type { AdminUser, AdminUserUpdate } from '@/types/user'
 import { useToast } from '@/composables/useToast'
 
 const toast = useToast()
+const route = useRoute()
 
 // Data
 const users = ref<AdminUser[]>([])
 const total = ref(0)
 const loading = ref(false)
+const cadetsReadyCount = ref(0)
 
 // Search and filters
 const searchInput = ref('')
 const search = ref('')
-const statusFilter = ref<number | null>(null)
+const statusFilter = ref<number | null>(
+  route.query.status !== undefined ? Number(route.query.status) : null,
+)
 const currentPage = ref(1)
 const pageSize = 50
 
@@ -139,12 +145,40 @@ watch([search, statusFilter], () => {
   loadUsers()
 })
 
-onMounted(loadUsers)
+onMounted(async () => {
+  loadUsers()
+  try {
+    const stats = await getAdminStats()
+    cadetsReadyCount.value = stats.cadets_ready_to_promote
+  } catch {
+    // silently fail
+  }
+})
 </script>
 
 <template>
   <div>
     <AppBreadcrumb />
+
+    <!-- Cadet readiness notification -->
+    <div
+      v-if="cadetsReadyCount > 0"
+      class="bg-green-50 border border-green-200 rounded-lg p-3 mb-4 flex items-center justify-between"
+    >
+      <div class="flex items-center text-green-800 text-sm">
+        <i class="fa-solid fa-circle-check text-green-600 mr-2"></i>
+        <span class="font-medium">
+          {{ cadetsReadyCount }} cadet{{ cadetsReadyCount > 1 ? 's' : '' }}
+          prêt{{ cadetsReadyCount > 1 ? 's' : '' }} à rejoindre l'association
+        </span>
+      </div>
+      <button
+        class="text-green-700 hover:text-green-900 text-sm font-medium underline"
+        @click="statusFilter = 1"
+      >
+        Voir les cadets
+      </button>
+    </div>
 
     <!-- Search & Filter -->
     <div class="flex flex-col sm:flex-row gap-3 mb-4">
@@ -279,7 +313,13 @@ onMounted(loadUsers)
             :key="u.id"
             class="border-b hover:bg-gray-50"
           >
-            <td class="p-2 font-medium">{{ u.nickname }}</td>
+            <td class="p-2 font-medium">
+              <i
+                v-if="u.is_ready_to_promote"
+                class="fa-solid fa-circle-check text-green-600 mr-1"
+                title="Prêt à rejoindre l'association"
+              ></i>{{ u.nickname }}
+            </td>
             <td class="p-2">{{ u.email }}</td>
             <td class="p-2">
               <span


### PR DESCRIPTION
## Summary by Sourcery

Add system-wide support and UI notifications for identifying cadets who are ready to become members, exposing this status via APIs, stats, and admin/roster views.

New Features:
- Expose a derived is_ready_to_promote flag on users and return it in admin user and roster APIs.
- Surface a cadets_ready_to_promote aggregate count in admin stats and roster stats endpoints.
- Display notifications and visual indicators in the admin dashboard, admin users list, and roster views when cadets are ready to join the association.

Documentation:
- Extend CLAUDE.md with a detailed project tree overview for backend, frontend, scripts, and docs.

Tests:
- Add unit tests for the User.is_ready_to_promote property.
- Add integration tests to ensure admin user listing and admin stats include cadet readiness information.