### PR TITLE
fix office page

### DIFF
--- a/backend/app/api/roster.py
+++ b/backend/app/api/roster.py
@@ -7,6 +7,8 @@ from app.database import get_db
 from app.models.module import Module
 from app.models.user import User, UserModule
 from app.schemas.roster import (
+    OfficeMemberOut,
+    OfficeOut,
     RosterModuleDetailOut,
     RosterModuleDetailUserOut,
     RosterModuleOut,
@@ -55,6 +57,27 @@ async def get_roster_stats(db: AsyncSession = Depends(get_db)):
         members=members_count or 0,
         cadets_need_presentation=cadets_need_presentation or 0,
         cadets_ready_to_promote=cadets_ready or 0,
+    )
+
+
+@router.get("/office", response_model=OfficeOut)
+async def get_roster_office(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(User).where(User.status.in_(User.STATUSES_OFFICE)))
+    users_by_status = {u.status: u for u in result.scalars().all()}
+
+    def _member(status: int) -> OfficeMemberOut | None:
+        u = users_by_status.get(status)
+        if u is None:
+            return None
+        return OfficeMemberOut(nickname=u.nickname, status=u.status, status_as_string=u.status_as_string)
+
+    return OfficeOut(
+        president=_member(User.STATUS_PRESIDENT),
+        president_deputy=_member(User.STATUS_PRESIDENT_DEPUTY),
+        treasurer=_member(User.STATUS_TREASURER),
+        treasurer_deputy=_member(User.STATUS_TREASURER_DEPUTY),
+        secretary=_member(User.STATUS_SECRETARY),
+        secretary_deputy=_member(User.STATUS_SECRETARY_DEPUTY),
     )
 
 

--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -44,3 +44,18 @@ class RosterModuleDetailUserOut(BaseModel):
 class RosterModuleDetailOut(BaseModel):
     module: RosterModuleOut
     users: list[RosterModuleDetailUserOut] = Field(default_factory=list)
+
+
+class OfficeMemberOut(BaseModel):
+    nickname: str
+    status: int
+    status_as_string: str | None = None
+
+
+class OfficeOut(BaseModel):
+    president: OfficeMemberOut | None = None
+    president_deputy: OfficeMemberOut | None = None
+    treasurer: OfficeMemberOut | None = None
+    treasurer_deputy: OfficeMemberOut | None = None
+    secretary: OfficeMemberOut | None = None
+    secretary_deputy: OfficeMemberOut | None = None

--- a/frontend/src/api/roster.ts
+++ b/frontend/src/api/roster.ts
@@ -47,7 +47,27 @@ export interface RosterModuleDetail {
   users: RosterModuleDetailUser[]
 }
 
+export interface OfficeMember {
+  nickname: string
+  status: number
+  status_as_string: string | null
+}
+
+export interface OfficeData {
+  president: OfficeMember | null
+  president_deputy: OfficeMember | null
+  treasurer: OfficeMember | null
+  treasurer_deputy: OfficeMember | null
+  secretary: OfficeMember | null
+  secretary_deputy: OfficeMember | null
+}
+
 // --- API functions ---
+
+export async function getOffice(): Promise<OfficeData> {
+  const { data } = await apiClient.get<OfficeData>('/roster/office')
+  return data
+}
 
 export async function getRosterStats(): Promise<RosterStats> {
   const { data } = await apiClient.get<RosterStats>('/roster/stats')

--- a/frontend/src/views/OfficeView.vue
+++ b/frontend/src/views/OfficeView.vue
@@ -1,32 +1,92 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import apiClient from '@/api/client'
+import { getOffice, type OfficeData, type OfficeMember } from '@/api/roster'
 
-const members = ref<any[]>([])
+const office = ref<OfficeData | null>(null)
 
 onMounted(async () => {
-  const { data } = await apiClient.get('/roster', { params: { group: 'office' } })
-  members.value = data
+  office.value = await getOffice()
 })
 
-const statusLabels: Record<number, string> = {
-  8: 'Président',
-  7: 'Vice-Président',
-  4: 'Secrétaire',
-  3: 'Secrétaire adjoint',
-  6: 'Trésorier',
-  5: 'Trésorier adjoint',
+interface Section {
+  title: string
+  icon: string
+  titular: { label: string; member: OfficeMember | null | undefined }
+  deputy: { label: string; member: OfficeMember | null | undefined }
+}
+
+function sections(): Section[] {
+  if (!office.value) return []
+  return [
+    {
+      title: 'Présidence',
+      icon: 'fa-solid fa-crown',
+      titular: { label: 'Président', member: office.value.president },
+      deputy: { label: 'Adjoint', member: office.value.president_deputy },
+    },
+    {
+      title: 'Trésorerie',
+      icon: 'fa-solid fa-coins',
+      titular: { label: 'Trésorier', member: office.value.treasurer },
+      deputy: { label: 'Adjoint', member: office.value.treasurer_deputy },
+    },
+    {
+      title: 'Secrétariat',
+      icon: 'fa-solid fa-pen',
+      titular: { label: 'Secrétaire', member: office.value.secretary },
+      deputy: { label: 'Adjoint', member: office.value.secretary_deputy },
+    },
+  ]
 }
 </script>
 
 <template>
-  <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6">Le Bureau</h1>
-    <div class="space-y-4">
-      <div v-for="m in members" :key="m.id" class="card !p-4 flex items-center justify-between">
-        <div>
-          <RouterLink :to="`/user/${m.nickname}`" class="font-semibold text-veaf-600">{{ m.nickname }}</RouterLink>
-          <p class="text-sm text-gray-500 capitalize">{{ statusLabels[m.status] || m.status_as_string }}</p>
+  <div class="max-w-5xl mx-auto">
+    <div class="card mb-8">
+      <h1 class="text-2xl font-bold mb-4">Le Bureau de l'association</h1>
+      <p class="text-gray-700">
+        La VEAF est une association française à but non lucratif — loi 1901.<br />
+        Elle dispose ainsi d'un cadre juridique pour encadrer la mise à disposition de moyens techniques afin de
+        promouvoir des activités de loisir liées à la simulation de combat aérien.
+      </p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div v-for="section in sections()" :key="section.title" class="card !p-0 overflow-hidden">
+        <!-- Header with gradient and icon -->
+        <div class="bg-veaf-gradient text-white text-center py-6">
+          <i :class="section.icon" class="text-5xl mb-2"></i>
+          <h2 class="text-lg font-semibold">{{ section.title }}</h2>
+        </div>
+
+        <!-- Body with titular + deputy -->
+        <div class="p-6 space-y-4">
+          <div>
+            <p class="text-xs font-medium text-gray-400 uppercase tracking-wide mb-1">{{ section.titular.label }}</p>
+            <p class="text-lg font-semibold">
+              <RouterLink
+                v-if="section.titular.member"
+                :to="`/user/${section.titular.member.nickname}`"
+                class="text-veaf-600 hover:text-veaf-800"
+              >
+                {{ section.titular.member.nickname }}
+              </RouterLink>
+              <span v-else class="text-gray-400">–</span>
+            </p>
+          </div>
+          <div>
+            <p class="text-xs font-medium text-gray-400 uppercase tracking-wide mb-1">{{ section.deputy.label }}</p>
+            <p class="text-lg font-semibold">
+              <RouterLink
+                v-if="section.deputy.member"
+                :to="`/user/${section.deputy.member.nickname}`"
+                class="text-veaf-600 hover:text-veaf-800"
+              >
+                {{ section.deputy.member.nickname }}
+              </RouterLink>
+              <span v-else class="text-gray-400">–</span>
+            </p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Update the office roster feature to use a dedicated backend endpoint and schema, and present the association’s office members in a structured, section-based layout on the frontend.

New Features:
- Add a backend /roster/office endpoint and associated OfficeOut and OfficeMemberOut schemas to expose office member data.
- Introduce a typed OfficeData/OfficeMember API on the frontend with a getOffice helper to fetch office information.
- Redesign the Office page to display office roles (president, treasurer, secretary and deputies) in distinct sections with improved layout and association context text.