### PR TITLE
add administration for files

### DIFF
--- a/backend/app/api/admin_files.py
+++ b/backend/app/api/admin_files.py
@@ -1,0 +1,110 @@
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth.dependencies import require_admin
+from app.config import settings
+from app.database import get_db
+from app.models.calendar import CalendarEvent
+from app.models.content import File
+from app.models.module import Module
+from app.models.user import User
+from app.schemas.content import AdminFileListOut, AdminFileOut
+
+router = APIRouter(prefix="/admin/files", tags=["admin-files"])
+
+
+def _delete_file_from_disk(file: File) -> None:
+    """Remove a file from disk storage. Silently ignores missing files."""
+    file_path = os.path.join(settings.UPLOAD_DIR, file.uuid[0], file.uuid[1], f"{file.uuid}.{file.extension}")
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+
+def _build_admin_file_out(file: File) -> AdminFileOut:
+    """Build an AdminFileOut DTO from a File model instance."""
+    return AdminFileOut(
+        id=file.id,
+        uuid=file.uuid,
+        type=file.type,
+        type_as_string=file.type_as_string,
+        mime_type=file.mime_type,
+        size=file.size,
+        original_name=file.original_name,
+        description=file.description,
+        extension=file.extension,
+        created_at=file.created_at,
+        owner_id=file.owner_id,
+        owner_nickname=file.owner.nickname if file.owner else None,
+    )
+
+
+@router.get("", response_model=AdminFileListOut)
+async def list_files(
+    search: str | None = Query(None),
+    type_filter: int | None = Query(None, alias="type"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(File)
+
+    if search:
+        pattern = f"%{search}%"
+        query = query.where(
+            or_(
+                File.original_name.ilike(pattern),
+                File.uuid.ilike(pattern),
+            )
+        )
+
+    if type_filter is not None:
+        query = query.where(File.type == type_filter)
+
+    # Count total
+    count_query = select(func.count()).select_from(query.subquery())
+    total = (await db.execute(count_query)).scalar_one()
+
+    # Fetch page
+    query = (
+        query.options(selectinload(File.owner))
+        .order_by(File.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    result = await db.execute(query)
+    files = result.scalars().all()
+
+    return AdminFileListOut(
+        items=[_build_admin_file_out(f) for f in files],
+        total=total,
+    )
+
+
+@router.delete("/{file_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_file(
+    file_id: int,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(File).where(File.id == file_id))
+    file = result.scalar_one_or_none()
+    if file is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Fichier non trouvé")
+
+    # Nullify all FK references to this file
+    await db.execute(update(CalendarEvent).where(CalendarEvent.image_id == file_id).values(image_id=None))
+    await db.execute(update(Module).where(Module.image_id == file_id).values(image_id=None))
+    await db.execute(update(Module).where(Module.image_header_id == file_id).values(image_header_id=None))
+
+    # Delete from disk
+    _delete_file_from_disk(file)
+
+    # Delete from DB
+    await db.delete(file)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/admin_stats.py
+++ b/backend/app/api/admin_stats.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.dependencies import require_admin
 from app.database import get_db
 from app.models.calendar import CalendarEvent
-from app.models.content import MenuItem, Page, Url
+from app.models.content import File, MenuItem, Page, Url
 from app.models.dcs import Server
 from app.models.module import Module
 from app.models.user import User
@@ -18,6 +18,7 @@ class AdminStats(BaseModel):
     modules: int = 0
     users: int = 0
     events: int = 0
+    files: int = 0
     pages: int = 0
     urls: int = 0
     menu_items: int = 0
@@ -38,6 +39,9 @@ async def get_stats(
 
     result = await db.execute(select(func.count()).select_from(CalendarEvent))
     events_count = result.scalar_one()
+
+    result = await db.execute(select(func.count()).select_from(File))
+    files_count = result.scalar_one()
 
     result = await db.execute(select(func.count()).select_from(Page))
     pages_count = result.scalar_one()
@@ -67,6 +71,7 @@ async def get_stats(
         modules=modules_count,
         users=users_count,
         events=events_count,
+        files=files_count,
         pages=pages_count,
         urls=urls_count,
         menu_items=menu_items_count,

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from app.api import admin_events, admin_menu, admin_modules, admin_pages, admin_servers, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, files, header, map, menu, metrics, mission_maker, modules, pages, recruitment, roster, servers, teamspeak, urls, users
+from app.api import admin_events, admin_files, admin_menu, admin_modules, admin_pages, admin_servers, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, files, header, map, menu, metrics, mission_maker, modules, pages, recruitment, roster, servers, teamspeak, urls, users
 
 api_router = APIRouter(prefix="/api")
 
 api_router.include_router(admin_events.router)
+api_router.include_router(admin_files.router)
 api_router.include_router(admin_menu.router)
 api_router.include_router(admin_modules.router)
 api_router.include_router(admin_pages.router)

--- a/backend/app/schemas/content.py
+++ b/backend/app/schemas/content.py
@@ -199,6 +199,28 @@ class FileOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class AdminFileOut(BaseModel):
+    id: int
+    uuid: str
+    type: int | None = None
+    type_as_string: str | None = None
+    mime_type: str
+    size: int
+    original_name: str | None = None
+    description: str | None = None
+    extension: str
+    created_at: datetime | None = None
+    owner_id: int | None = None
+    owner_nickname: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class AdminFileListOut(BaseModel):
+    items: list[AdminFileOut]
+    total: int
+
+
 class UrlOut(BaseModel):
     id: int
     slug: str

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,6 +1,7 @@
 """Factory-boy factories for test data creation."""
 
 from datetime import UTC, datetime
+from uuid import uuid4
 
 import factory
 
@@ -135,3 +136,16 @@ class EventFactory(factory.Factory):
     registration = True
     created_at = factory.LazyFunction(lambda: datetime.now(UTC))
     updated_at = factory.LazyFunction(lambda: datetime.now(UTC))
+
+
+class FileFactory(factory.Factory):
+    class Meta:
+        model = File
+
+    uuid = factory.LazyFunction(lambda: str(uuid4()))
+    mime_type = "image/png"
+    size = 1024
+    extension = "png"
+    type = File.TYPE_IMAGE
+    original_name = factory.Sequence(lambda n: f"file_{n}.png")
+    created_at = factory.LazyFunction(lambda: datetime.now(UTC))

--- a/backend/tests/integration/api/test_admin_files.py
+++ b/backend/tests/integration/api/test_admin_files.py
@@ -1,0 +1,284 @@
+"""Integration tests for admin file endpoints."""
+
+import os
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import create_access_token
+from app.config import settings
+from app.models.calendar import CalendarEvent
+from app.models.content import File
+from app.models.module import Module
+from app.models.user import User
+from tests.factories import AdminFactory, EventFactory, FileFactory, ModuleFactory, UserFactory
+
+
+async def _create_admin(db: AsyncSession) -> tuple:
+    """Create an admin user and return (user, auth_headers)."""
+    user = AdminFactory.build()
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_user(db: AsyncSession, **kwargs) -> tuple:
+    """Create a regular user and return (user, auth_headers)."""
+    user = UserFactory.build(**kwargs)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_file(db: AsyncSession, owner_id: int | None = None, **kwargs) -> File:
+    """Create a File record and return it."""
+    file = FileFactory.build(owner_id=owner_id, **kwargs)
+    db.add(file)
+    await db.commit()
+    await db.refresh(file)
+    return file
+
+
+def _create_file_on_disk(file: File) -> str:
+    """Create a fake file on disk for the given File model. Returns the file path."""
+    dir_path = os.path.join(settings.UPLOAD_DIR, file.uuid[0], file.uuid[1])
+    os.makedirs(dir_path, exist_ok=True)
+    file_path = os.path.join(dir_path, f"{file.uuid}.{file.extension}")
+    with open(file_path, "wb") as f:
+        f.write(b"fake content")
+    return file_path
+
+
+# =============================================================================
+# List files
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_files_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    await _create_file(db_session, owner_id=admin.id, original_name="photo.png")
+    await _create_file(db_session, owner_id=admin.id, original_name="document.pdf")
+
+    # WHEN
+    response = await client.get("/api/admin/files", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] == 2
+    item = data["items"][0]
+    assert "uuid" in item
+    assert "original_name" in item
+    assert "type_as_string" in item
+    assert "owner_nickname" in item
+
+
+@pytest.mark.asyncio
+async def test_list_files_search_by_name(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    await _create_file(db_session, owner_id=admin.id, original_name="mission_briefing.pdf")
+    await _create_file(db_session, owner_id=admin.id, original_name="screenshot.png")
+
+    # WHEN
+    response = await client.get("/api/admin/files?search=briefing", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["original_name"] == "mission_briefing.pdf"
+
+
+@pytest.mark.asyncio
+async def test_list_files_search_by_uuid(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    file1 = await _create_file(db_session, owner_id=admin.id)
+    await _create_file(db_session, owner_id=admin.id)
+
+    # WHEN — search by first 8 chars of UUID
+    search_term = file1.uuid[:8]
+    response = await client.get(f"/api/admin/files?search={search_term}", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 1
+    uuids = [item["uuid"] for item in data["items"]]
+    assert file1.uuid in uuids
+
+
+@pytest.mark.asyncio
+async def test_list_files_filter_by_type(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    await _create_file(db_session, owner_id=admin.id, type=File.TYPE_IMAGE)
+    await _create_file(db_session, owner_id=admin.id, type=File.TYPE_PDF, mime_type="application/pdf", extension="pdf")
+
+    # WHEN
+    response = await client.get(f"/api/admin/files?type={File.TYPE_PDF}", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["type"] == File.TYPE_PDF
+
+
+@pytest.mark.asyncio
+async def test_list_files_pagination(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    for _ in range(5):
+        await _create_file(db_session, owner_id=admin.id)
+
+    # WHEN
+    response = await client.get("/api/admin/files?skip=2&limit=2", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_files_unauthenticated(client: AsyncClient):
+    # GIVEN — no auth headers
+
+    # WHEN
+    response = await client.get("/api/admin/files")
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_files_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.get("/api/admin/files", headers=headers)
+
+    # THEN
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Delete file
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_file_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    file = await _create_file(db_session, owner_id=admin.id)
+    disk_path = _create_file_on_disk(file)
+    assert os.path.exists(disk_path)
+
+    # WHEN
+    response = await client.delete(f"/api/admin/files/{file.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    # File removed from DB
+    result = await db_session.execute(select(File).where(File.id == file.id))
+    assert result.scalar_one_or_none() is None
+    # File removed from disk
+    assert not os.path.exists(disk_path)
+
+
+@pytest.mark.asyncio
+async def test_delete_file_nullifies_event_image(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    file = await _create_file(db_session, owner_id=admin.id)
+    event = EventFactory.build(owner_id=admin.id, image_id=file.id)
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+
+    # WHEN
+    response = await client.delete(f"/api/admin/files/{file.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    await db_session.refresh(event)
+    assert event.image_id is None
+
+
+@pytest.mark.asyncio
+async def test_delete_file_nullifies_module_images(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    file_img = await _create_file(db_session, owner_id=admin.id)
+    file_header = await _create_file(db_session, owner_id=admin.id)
+    module = ModuleFactory.build(image_id=file_img.id, image_header_id=file_header.id)
+    db_session.add(module)
+    await db_session.commit()
+    await db_session.refresh(module)
+
+    # WHEN — delete the image file
+    response = await client.delete(f"/api/admin/files/{file_img.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    await db_session.refresh(module)
+    assert module.image_id is None
+    assert module.image_header_id == file_header.id  # untouched
+
+    # WHEN — delete the header file
+    response = await client.delete(f"/api/admin/files/{file_header.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    await db_session.refresh(module)
+    assert module.image_header_id is None
+
+
+@pytest.mark.asyncio
+async def test_delete_file_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.delete("/api/admin/files/9999", headers=headers)
+
+    # THEN
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_file_unauthenticated(client: AsyncClient):
+    # GIVEN — no auth headers
+
+    # WHEN
+    response = await client.delete("/api/admin/files/1")
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_file_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.delete("/api/admin/files/1", headers=headers)
+
+    # THEN
+    assert response.status_code == 403

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -4,6 +4,7 @@ export interface AdminStats {
   modules: number
   users: number
   events: number
+  files: number
   pages: number
   urls: number
   menu_items: number

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -17,3 +17,41 @@ export async function uploadFile(file: File): Promise<FileUploadResult> {
   const { data } = await apiClient.post<FileUploadResult>('/files', formData)
   return data
 }
+
+// --- Admin File types ---
+
+export interface AdminFile {
+  id: number
+  uuid: string
+  type: number | null
+  type_as_string: string | null
+  mime_type: string
+  size: number
+  original_name: string | null
+  description: string | null
+  extension: string
+  created_at: string | null
+  owner_id: number | null
+  owner_nickname: string | null
+}
+
+export interface AdminFileListResponse {
+  items: AdminFile[]
+  total: number
+}
+
+// --- Admin File API functions ---
+
+export async function getAdminFiles(params?: {
+  search?: string
+  type?: number
+  skip?: number
+  limit?: number
+}): Promise<AdminFileListResponse> {
+  const { data } = await apiClient.get<AdminFileListResponse>('/admin/files', { params })
+  return data
+}
+
+export async function deleteAdminFile(fileId: number): Promise<void> {
+  await apiClient.delete(`/admin/files/${fileId}`)
+}

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -56,7 +56,7 @@ onMounted(async () => {
       </RouterLink>
       <RouterLink to="/admin/files" class="card text-center hover:shadow-md transition-shadow">
         <div class="text-veaf-400 mb-2"><i class="fa-solid fa-folder-open text-2xl"></i></div>
-        <div class="text-3xl font-bold text-veaf-500 mb-2">-</div>
+        <div class="text-3xl font-bold text-veaf-500 mb-2">{{ stats?.files ?? '-' }}</div>
         <div class="text-sm text-gray-900">Fichiers</div>
       </RouterLink>
       <RouterLink to="/admin/servers" class="card text-center hover:shadow-md transition-shadow">

--- a/frontend/src/views/admin/FilesView.vue
+++ b/frontend/src/views/admin/FilesView.vue
@@ -1,10 +1,276 @@
 <script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { getAdminFiles, deleteAdminFile } from '@/api/files'
+import type { AdminFile } from '@/api/files'
 import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
+import { useToast } from '@/composables/useToast'
+import { useConfirm } from '@/composables/useConfirm'
+
+const toast = useToast()
+const { confirm } = useConfirm()
+
+// localStorage persistence helpers
+const STORAGE_PREFIX = 'admin.files.'
+
+function loadStorage<T>(key: string, defaultValue: T): T {
+  const raw = localStorage.getItem(STORAGE_PREFIX + key)
+  if (raw === null) return defaultValue
+  try { return JSON.parse(raw) } catch { return defaultValue }
+}
+
+function saveStorage(key: string, value: unknown): void {
+  localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(value))
+}
+
+// Data
+const files = ref<AdminFile[]>([])
+const total = ref(0)
+const loading = ref(false)
+
+// Search and filters (restored from localStorage)
+const searchInput = ref(loadStorage<string>('search', ''))
+const search = ref(loadStorage<string>('search', ''))
+const typeFilter = ref(loadStorage<number | null>('typeFilter', null))
+const currentPage = ref(loadStorage<number>('currentPage', 1))
+const pageSize = ref(loadStorage<number>('pageSize', 50))
+const pageSizeOptions = [10, 20, 50, 100]
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+
+function onSearchInput() {
+  if (searchTimeout) clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    search.value = searchInput.value
+  }, 300)
+}
+
+const typeOptions = [
+  { value: 1, label: 'Image' },
+  { value: 2, label: 'PDF' },
+  { value: 0, label: 'Inconnu' },
+]
+
+const totalPages = computed(() => Math.ceil(total.value / pageSize.value))
+
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 o'
+  const units = ['o', 'Ko', 'Mo', 'Go']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  return (bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1) + ' ' + units[i]
+}
+
+function formatDateTime(dateStr: string | null): string {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function fileUrl(uuid: string): string {
+  return `/api/files/${uuid}`
+}
+
+async function loadFiles() {
+  loading.value = true
+  try {
+    const params: Record<string, string | number> = {
+      skip: (currentPage.value - 1) * pageSize.value,
+      limit: pageSize.value,
+    }
+    if (search.value) params.search = search.value
+    if (typeFilter.value !== null) params.type = typeFilter.value
+
+    const result = await getAdminFiles(params)
+    files.value = result.items
+    total.value = result.total
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleDelete(file: AdminFile) {
+  const name = file.original_name || file.uuid
+  const ok = await confirm(`Supprimer le fichier « ${name} » ? Cette action est irréversible.`)
+  if (!ok) return
+  try {
+    await deleteAdminFile(file.id)
+    toast.success('Fichier supprimé avec succès')
+    await loadFiles()
+  } catch (e) {
+    toast.error(e)
+  }
+}
+
+function goToPage(page: number) {
+  if (page < 1 || page > totalPages.value) return
+  currentPage.value = page
+  loadFiles()
+}
+
+watch([search, typeFilter, pageSize], () => {
+  currentPage.value = 1
+  loadFiles()
+})
+
+// Persist all filter/pagination state to localStorage
+watch([search, typeFilter, currentPage, pageSize], () => {
+  saveStorage('search', search.value)
+  saveStorage('typeFilter', typeFilter.value)
+  saveStorage('currentPage', currentPage.value)
+  saveStorage('pageSize', pageSize.value)
+})
+
+onMounted(loadFiles)
 </script>
 
 <template>
   <div>
     <AppBreadcrumb />
-    <div class="card text-center py-12 text-gray-500">Administration des fichiers (Phase 4)</div>
+
+    <!-- Search & Filters -->
+    <div class="flex flex-col sm:flex-row gap-3 mb-4">
+      <div class="relative flex-1">
+        <i class="fa-solid fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm"></i>
+        <input
+          :value="searchInput"
+          type="text"
+          class="input pl-9 w-full"
+          placeholder="Rechercher par UUID ou nom de fichier..."
+          @input="searchInput = ($event.target as HTMLInputElement).value; onSearchInput()"
+        />
+      </div>
+      <select
+        :value="typeFilter ?? ''"
+        class="input w-full sm:w-48"
+        @change="typeFilter = ($event.target as HTMLSelectElement).value === '' ? null : Number(($event.target as HTMLSelectElement).value)"
+      >
+        <option value="">Tous les types</option>
+        <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
+    </div>
+
+    <!-- Files table -->
+    <div class="card overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b text-left">
+            <th class="p-2">Aperçu</th>
+            <th class="p-2">Nom original</th>
+            <th class="p-2">UUID</th>
+            <th class="p-2">Type</th>
+            <th class="p-2">Taille</th>
+            <th class="p-2">Propriétaire</th>
+            <th class="p-2">Créé le</th>
+            <th class="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="loading && !files.length">
+            <td colspan="8" class="p-4 text-center text-gray-500">Chargement...</td>
+          </tr>
+          <tr v-else-if="!files.length">
+            <td colspan="8" class="p-4 text-center text-gray-500">Aucun fichier</td>
+          </tr>
+          <tr
+            v-for="file in files"
+            :key="file.id"
+            class="border-b hover:bg-gray-50"
+          >
+            <td class="p-2">
+              <img
+                v-if="file.type === 1"
+                :src="fileUrl(file.uuid)"
+                class="w-10 h-10 object-cover rounded"
+                loading="lazy"
+              />
+              <i v-else-if="file.type === 2" class="fa-solid fa-file-pdf text-red-500 text-xl"></i>
+              <i v-else class="fa-solid fa-file text-gray-400 text-xl"></i>
+            </td>
+            <td class="p-2 font-medium">{{ file.original_name ?? '-' }}</td>
+            <td class="p-2 font-mono text-xs text-gray-500" :title="file.uuid">
+              {{ file.uuid.substring(0, 8) }}...
+            </td>
+            <td class="p-2">
+              <span
+                class="inline-block px-2 py-0.5 rounded-full text-xs font-medium"
+                :class="{
+                  'bg-blue-100 text-blue-800': file.type === 1,
+                  'bg-red-100 text-red-800': file.type === 2,
+                  'bg-gray-100 text-gray-800': file.type !== 1 && file.type !== 2,
+                }"
+              >
+                {{ file.type_as_string ?? 'inconnu' }}
+              </span>
+            </td>
+            <td class="p-2 whitespace-nowrap">{{ formatFileSize(file.size) }}</td>
+            <td class="p-2">{{ file.owner_nickname ?? '-' }}</td>
+            <td class="p-2 whitespace-nowrap">{{ formatDateTime(file.created_at) }}</td>
+            <td class="p-2 whitespace-nowrap">
+              <a
+                :href="fileUrl(file.uuid)"
+                target="_blank"
+                class="text-veaf-600 hover:text-veaf-800 text-sm mr-3"
+                title="Télécharger"
+              >
+                <i class="fa-solid fa-download"></i>
+              </a>
+              <button
+                class="text-red-600 hover:text-red-800 text-sm"
+                title="Supprimer"
+                @click="handleDelete(file)"
+              >
+                <i class="fa-solid fa-trash"></i>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div class="flex items-center justify-between mt-4">
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-gray-600">
+          {{ total }} fichier{{ total > 1 ? 's' : '' }}
+        </span>
+        <select
+          :value="pageSize"
+          class="input text-sm py-1 w-auto"
+          @change="pageSize = Number(($event.target as HTMLSelectElement).value)"
+        >
+          <option v-for="size in pageSizeOptions" :key="size" :value="size">
+            {{ size }} / page
+          </option>
+        </select>
+      </div>
+      <div v-if="totalPages > 1" class="flex items-center space-x-2">
+        <button
+          class="btn-secondary text-sm"
+          :disabled="currentPage <= 1"
+          @click="goToPage(currentPage - 1)"
+        >
+          <i class="fa-solid fa-chevron-left mr-1"></i>Précédent
+        </button>
+        <span class="text-sm text-gray-600">
+          Page {{ currentPage }} sur {{ totalPages }}
+        </span>
+        <button
+          class="btn-secondary text-sm"
+          :disabled="currentPage >= totalPages"
+          @click="goToPage(currentPage + 1)"
+        >
+          Suivant<i class="fa-solid fa-chevron-right ml-1"></i>
+        </button>
+      </div>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary by Sourcery

Introduce an admin-facing file management feature with listing, filtering, pagination, deletion, and statistics integration across frontend and backend.

New Features:
- Add admin API endpoints to list and delete files, including search, type filtering, and pagination.
- Expose admin file data to the frontend and implement an admin files view with search, filters, previews, pagination, and delete actions.
- Extend admin statistics to include the total number of files and display it on the admin dashboard.

Enhancements:
- Persist admin files filters and pagination state in localStorage for a better admin UX.
- Ensure file deletions also remove files from disk and clear related references from events and modules.

Tests:
- Add integration tests covering admin file listing (filters, search, pagination, auth) and deletion behaviors, including cleanup of related entities.

Chores:
- Add a test factory for the File model to support admin file tests.