### PR TITLE
admin cadets events

### DIFF
--- a/backend/app/api/admin_recruitment.py
+++ b/backend/app/api/admin_recruitment.py
@@ -1,0 +1,122 @@
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth.dependencies import require_admin
+from app.database import get_db
+from app.models.recruitment import RecruitmentEvent
+from app.models.user import User
+from app.schemas.recruitment import AdminRecruitmentEventListOut, AdminRecruitmentEventOut, AdminRecruitmentEventUpdate
+
+router = APIRouter(prefix="/admin/recruitment", tags=["admin-recruitment"])
+
+
+def _build_admin_event_out(event: RecruitmentEvent) -> AdminRecruitmentEventOut:
+    """Build an AdminRecruitmentEventOut DTO from a RecruitmentEvent model instance."""
+    return AdminRecruitmentEventOut(
+        id=event.id,
+        type=event.type,
+        type_as_string=event.type_as_string,
+        event_at=event.event_at,
+        comment=event.comment,
+        ack_at=event.ack_at,
+        user_id=event.user_id,
+        user_nickname=event.user.nickname if event.user else None,
+        validator_id=event.validator_id,
+        validator_nickname=event.validator.nickname if event.validator else None,
+        created_at=event.created_at,
+        updated_at=event.updated_at,
+    )
+
+
+@router.get("", response_model=AdminRecruitmentEventListOut)
+async def list_recruitment_events(
+    search: str | None = Query(None),
+    type_filter: int | None = Query(None, alias="type"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(RecruitmentEvent)
+
+    if search:
+        pattern = f"%{search}%"
+        query = query.where(RecruitmentEvent.user_id.in_(select(User.id).where(User.nickname.ilike(pattern))))
+
+    if type_filter is not None:
+        query = query.where(RecruitmentEvent.type == type_filter)
+
+    # Count total
+    count_query = select(func.count()).select_from(query.subquery())
+    total = (await db.execute(count_query)).scalar_one()
+
+    # Fetch page
+    query = (
+        query.options(selectinload(RecruitmentEvent.user), selectinload(RecruitmentEvent.validator))
+        .order_by(RecruitmentEvent.event_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    result = await db.execute(query)
+    events = result.scalars().all()
+
+    return AdminRecruitmentEventListOut(
+        items=[_build_admin_event_out(e) for e in events],
+        total=total,
+    )
+
+
+@router.put("/{event_id}", response_model=AdminRecruitmentEventOut)
+async def update_recruitment_event(
+    event_id: int,
+    data: AdminRecruitmentEventUpdate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(RecruitmentEvent)
+        .where(RecruitmentEvent.id == event_id)
+        .options(selectinload(RecruitmentEvent.user), selectinload(RecruitmentEvent.validator))
+    )
+    event = result.scalar_one_or_none()
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Activité non trouvée")
+
+    event.comment = data.comment
+    event.event_at = data.event_at
+    event.updated_at = datetime.now(UTC)
+
+    await db.commit()
+    await db.refresh(event, attribute_names=["user", "validator"])
+    return _build_admin_event_out(event)
+
+
+@router.delete("/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_recruitment_event(
+    event_id: int,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(RecruitmentEvent).where(RecruitmentEvent.id == event_id).options(selectinload(RecruitmentEvent.user))
+    )
+    event = result.scalar_one_or_none()
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Activité non trouvée")
+
+    # Reverse side effects
+    target = event.user
+    if event.type == RecruitmentEvent.TYPE_ACTIVITY and target:
+        target.cadet_flights = max(0, target.cadet_flights - 1)
+        target.updated_at = datetime.now(UTC)
+    elif event.type == RecruitmentEvent.TYPE_PRESENTATION and target:
+        target.need_presentation = True
+        target.updated_at = datetime.now(UTC)
+
+    await db.delete(event)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/admin_stats.py
+++ b/backend/app/api/admin_stats.py
@@ -9,6 +9,7 @@ from app.models.calendar import CalendarEvent
 from app.models.content import File, MenuItem, Page, Url
 from app.models.dcs import Server
 from app.models.module import Module
+from app.models.recruitment import RecruitmentEvent
 from app.models.user import User
 
 router = APIRouter(prefix="/admin/stats", tags=["admin-stats"])
@@ -24,6 +25,7 @@ class AdminStats(BaseModel):
     menu_items: int = 0
     servers: int = 0
     cadets_ready_to_promote: int = 0
+    recruitment_events: int = 0
 
 
 @router.get("", response_model=AdminStats)
@@ -67,6 +69,9 @@ async def get_stats(
     )
     cadets_ready_count = result.scalar_one()
 
+    result = await db.execute(select(func.count()).select_from(RecruitmentEvent))
+    recruitment_events_count = result.scalar_one()
+
     return AdminStats(
         modules=modules_count,
         users=users_count,
@@ -77,4 +82,5 @@ async def get_stats(
         menu_items=menu_items_count,
         servers=servers_count,
         cadets_ready_to_promote=cadets_ready_count,
+        recruitment_events=recruitment_events_count,
     )

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api import admin_events, admin_files, admin_menu, admin_modules, admin_pages, admin_servers, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, files, header, map, menu, metrics, mission_maker, modules, pages, recruitment, roster, servers, teamspeak, urls, users
+from app.api import admin_events, admin_files, admin_menu, admin_modules, admin_pages, admin_recruitment, admin_servers, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, files, header, map, menu, metrics, mission_maker, modules, pages, recruitment, roster, servers, teamspeak, urls, users
 
 api_router = APIRouter(prefix="/api")
 
@@ -9,6 +9,7 @@ api_router.include_router(admin_files.router)
 api_router.include_router(admin_menu.router)
 api_router.include_router(admin_modules.router)
 api_router.include_router(admin_pages.router)
+api_router.include_router(admin_recruitment.router)
 api_router.include_router(admin_servers.router)
 api_router.include_router(admin_stats.router)
 api_router.include_router(admin_urls.router)

--- a/backend/app/schemas/recruitment.py
+++ b/backend/app/schemas/recruitment.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class AdminRecruitmentEventOut(BaseModel):
+    id: int
+    type: int
+    type_as_string: str
+    event_at: datetime | None = None
+    comment: str | None = None
+    ack_at: datetime | None = None
+    user_id: int
+    user_nickname: str | None = None
+    validator_id: int | None = None
+    validator_nickname: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class AdminRecruitmentEventListOut(BaseModel):
+    items: list[AdminRecruitmentEventOut] = Field(default_factory=list)
+    total: int
+
+
+class AdminRecruitmentEventUpdate(BaseModel):
+    comment: str | None = Field(None, max_length=255)
+    event_at: datetime | None = None

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -138,6 +138,17 @@ class EventFactory(factory.Factory):
     updated_at = factory.LazyFunction(lambda: datetime.now(UTC))
 
 
+class RecruitmentEventFactory(factory.Factory):
+    class Meta:
+        model = RecruitmentEvent
+
+    type = RecruitmentEvent.TYPE_ACTIVITY
+    comment = factory.Sequence(lambda n: f"Activity {n}")
+    event_at = factory.LazyFunction(lambda: datetime.now(UTC))
+    created_at = factory.LazyFunction(lambda: datetime.now(UTC))
+    updated_at = factory.LazyFunction(lambda: datetime.now(UTC))
+
+
 class FileFactory(factory.Factory):
     class Meta:
         model = File

--- a/backend/tests/integration/api/test_admin_recruitment.py
+++ b/backend/tests/integration/api/test_admin_recruitment.py
@@ -1,0 +1,327 @@
+"""Integration tests for admin recruitment endpoints."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import create_access_token
+from app.models.recruitment import RecruitmentEvent
+from app.models.user import User
+from tests.factories import AdminFactory, RecruitmentEventFactory, UserFactory
+
+
+async def _create_admin(db: AsyncSession) -> tuple:
+    """Create an admin user and return (user, auth_headers)."""
+    user = AdminFactory.build()
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_user(db: AsyncSession, **kwargs) -> tuple:
+    """Create a regular user and return (user, auth_headers)."""
+    user = UserFactory.build(**kwargs)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_event(db: AsyncSession, user_id: int, validator_id: int | None = None, **kwargs) -> RecruitmentEvent:
+    """Create a RecruitmentEvent and return it."""
+    event = RecruitmentEventFactory.build(user_id=user_id, validator_id=validator_id, **kwargs)
+    db.add(event)
+    await db.commit()
+    await db.refresh(event)
+    return event
+
+
+# =============================================================================
+# List recruitment events
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_recruitment_events_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet = UserFactory.build(status=User.STATUS_CADET, nickname="CadetAlpha")
+    db_session.add(cadet)
+    await db_session.commit()
+    await db_session.refresh(cadet)
+    await _create_event(db_session, user_id=cadet.id, validator_id=admin.id)
+    await _create_event(db_session, user_id=cadet.id, validator_id=admin.id, type=RecruitmentEvent.TYPE_PRESENTATION)
+
+    # WHEN
+    response = await client.get("/api/admin/recruitment", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] == 2
+    item = data["items"][0]
+    assert "type" in item
+    assert "type_as_string" in item
+    assert "user_nickname" in item
+    assert "validator_nickname" in item
+
+
+@pytest.mark.asyncio
+async def test_list_recruitment_events_search_by_cadet_nickname(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet1 = UserFactory.build(status=User.STATUS_CADET, nickname="AlphaWolf")
+    cadet2 = UserFactory.build(status=User.STATUS_CADET, nickname="BravoBear")
+    db_session.add_all([cadet1, cadet2])
+    await db_session.commit()
+    await db_session.refresh(cadet1)
+    await db_session.refresh(cadet2)
+    await _create_event(db_session, user_id=cadet1.id, validator_id=admin.id)
+    await _create_event(db_session, user_id=cadet2.id, validator_id=admin.id)
+
+    # WHEN
+    response = await client.get("/api/admin/recruitment?search=Alpha", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["user_nickname"] == "AlphaWolf"
+
+
+@pytest.mark.asyncio
+async def test_list_recruitment_events_filter_by_type(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet = UserFactory.build(status=User.STATUS_CADET)
+    db_session.add(cadet)
+    await db_session.commit()
+    await db_session.refresh(cadet)
+    await _create_event(db_session, user_id=cadet.id, validator_id=admin.id, type=RecruitmentEvent.TYPE_ACTIVITY)
+    await _create_event(db_session, user_id=cadet.id, validator_id=admin.id, type=RecruitmentEvent.TYPE_PRESENTATION)
+
+    # WHEN
+    response = await client.get(f"/api/admin/recruitment?type={RecruitmentEvent.TYPE_ACTIVITY}", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["type"] == RecruitmentEvent.TYPE_ACTIVITY
+
+
+@pytest.mark.asyncio
+async def test_list_recruitment_events_pagination(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet = UserFactory.build(status=User.STATUS_CADET)
+    db_session.add(cadet)
+    await db_session.commit()
+    await db_session.refresh(cadet)
+    for _ in range(5):
+        await _create_event(db_session, user_id=cadet.id, validator_id=admin.id)
+
+    # WHEN
+    response = await client.get("/api/admin/recruitment?skip=2&limit=2", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_recruitment_events_unauthenticated(client: AsyncClient):
+    # GIVEN — no auth headers
+
+    # WHEN
+    response = await client.get("/api/admin/recruitment")
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_recruitment_events_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.get("/api/admin/recruitment", headers=headers)
+
+    # THEN
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Update recruitment event
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_recruitment_event_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet = UserFactory.build(status=User.STATUS_CADET)
+    db_session.add(cadet)
+    await db_session.commit()
+    await db_session.refresh(cadet)
+    event = await _create_event(db_session, user_id=cadet.id, validator_id=admin.id, comment="old comment")
+
+    # WHEN
+    response = await client.put(
+        f"/api/admin/recruitment/{event.id}",
+        headers=headers,
+        json={"comment": "updated comment", "event_at": "2026-01-15T14:30:00Z"},
+    )
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["comment"] == "updated comment"
+    assert "2026-01-15" in data["event_at"]
+
+
+@pytest.mark.asyncio
+async def test_update_recruitment_event_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.put(
+        "/api/admin/recruitment/9999",
+        headers=headers,
+        json={"comment": "test"},
+    )
+
+    # THEN
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_recruitment_event_unauthenticated(client: AsyncClient):
+    # GIVEN — no auth headers
+
+    # WHEN
+    response = await client.put("/api/admin/recruitment/1", json={"comment": "test"})
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_update_recruitment_event_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.put("/api/admin/recruitment/1", headers=headers, json={"comment": "test"})
+
+    # THEN
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Delete recruitment event
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_recruitment_event_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet = UserFactory.build(status=User.STATUS_CADET)
+    db_session.add(cadet)
+    await db_session.commit()
+    await db_session.refresh(cadet)
+    event = await _create_event(db_session, user_id=cadet.id, validator_id=admin.id, type=RecruitmentEvent.TYPE_GUEST)
+
+    # WHEN
+    response = await client.delete(f"/api/admin/recruitment/{event.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    result = await db_session.execute(select(RecruitmentEvent).where(RecruitmentEvent.id == event.id))
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_event_decrements_cadet_flights(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet = UserFactory.build(status=User.STATUS_CADET, cadet_flights=3)
+    db_session.add(cadet)
+    await db_session.commit()
+    await db_session.refresh(cadet)
+    event = await _create_event(db_session, user_id=cadet.id, validator_id=admin.id, type=RecruitmentEvent.TYPE_ACTIVITY)
+
+    # WHEN
+    response = await client.delete(f"/api/admin/recruitment/{event.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    await db_session.refresh(cadet)
+    assert cadet.cadet_flights == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_presentation_event_restores_need_presentation(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    admin, headers = await _create_admin(db_session)
+    cadet = UserFactory.build(status=User.STATUS_CADET, need_presentation=False)
+    db_session.add(cadet)
+    await db_session.commit()
+    await db_session.refresh(cadet)
+    event = await _create_event(
+        db_session, user_id=cadet.id, validator_id=admin.id, type=RecruitmentEvent.TYPE_PRESENTATION
+    )
+
+    # WHEN
+    response = await client.delete(f"/api/admin/recruitment/{event.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    await db_session.refresh(cadet)
+    assert cadet.need_presentation is True
+
+
+@pytest.mark.asyncio
+async def test_delete_recruitment_event_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.delete("/api/admin/recruitment/9999", headers=headers)
+
+    # THEN
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_recruitment_event_unauthenticated(client: AsyncClient):
+    # GIVEN — no auth headers
+
+    # WHEN
+    response = await client.delete("/api/admin/recruitment/1")
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_recruitment_event_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.delete("/api/admin/recruitment/1", headers=headers)
+
+    # THEN
+    assert response.status_code == 403

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -10,6 +10,7 @@ export interface AdminStats {
   menu_items: number
   servers: number
   cadets_ready_to_promote: number
+  recruitment_events: number
 }
 
 export async function getAdminStats(): Promise<AdminStats> {

--- a/frontend/src/api/recruitment.ts
+++ b/frontend/src/api/recruitment.ts
@@ -27,3 +27,57 @@ export async function addRecruitmentEvent(
     params: { type, ...(comment ? { comment } : {}) },
   })
 }
+
+// --- Admin Recruitment ---
+
+export interface AdminRecruitmentEvent {
+  id: number
+  type: number
+  type_as_string: string
+  event_at: string | null
+  comment: string | null
+  ack_at: string | null
+  user_id: number
+  user_nickname: string | null
+  validator_id: number | null
+  validator_nickname: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface AdminRecruitmentEventListResponse {
+  items: AdminRecruitmentEvent[]
+  total: number
+}
+
+export interface AdminRecruitmentEventUpdate {
+  comment: string | null
+  event_at: string | null
+}
+
+export async function getAdminRecruitmentEvents(params?: {
+  search?: string
+  type?: number
+  skip?: number
+  limit?: number
+}): Promise<AdminRecruitmentEventListResponse> {
+  const { data } = await apiClient.get<AdminRecruitmentEventListResponse>('/admin/recruitment', {
+    params,
+  })
+  return data
+}
+
+export async function updateAdminRecruitmentEvent(
+  eventId: number,
+  payload: AdminRecruitmentEventUpdate,
+): Promise<AdminRecruitmentEvent> {
+  const { data } = await apiClient.put<AdminRecruitmentEvent>(
+    `/admin/recruitment/${eventId}`,
+    payload,
+  )
+  return data
+}
+
+export async function deleteAdminRecruitmentEvent(eventId: number): Promise<void> {
+  await apiClient.delete(`/admin/recruitment/${eventId}`)
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -283,6 +283,19 @@ const router = createRouter({
         ],
       },
     },
+    {
+      path: '/admin/activities',
+      name: 'admin-activities',
+      component: () => import('@/views/admin/ActivitiesView.vue'),
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Activités' },
+        ],
+      },
+    },
     // Error pages
     {
       path: '/error/404',

--- a/frontend/src/views/admin/ActivitiesView.vue
+++ b/frontend/src/views/admin/ActivitiesView.vue
@@ -1,0 +1,299 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import {
+  getAdminRecruitmentEvents,
+  updateAdminRecruitmentEvent,
+  deleteAdminRecruitmentEvent,
+} from '@/api/recruitment'
+import type { AdminRecruitmentEvent } from '@/api/recruitment'
+import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
+import { useToast } from '@/composables/useToast'
+import { useConfirm } from '@/composables/useConfirm'
+
+const toast = useToast()
+const { confirm } = useConfirm()
+
+// Data
+const events = ref<AdminRecruitmentEvent[]>([])
+const total = ref(0)
+const loading = ref(false)
+
+// Search and filters
+const searchInput = ref('')
+const search = ref('')
+const typeFilter = ref<number | null>(null)
+const currentPage = ref(1)
+const pageSize = 50
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+
+function onSearchInput() {
+  if (searchTimeout) clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    search.value = searchInput.value
+  }, 300)
+}
+
+const typeOptions = [
+  { value: 1, label: 'Candidature' },
+  { value: 2, label: 'Présentation' },
+  { value: 3, label: 'Promotion' },
+  { value: 4, label: 'Activité' },
+  { value: 5, label: 'Invité' },
+]
+
+const totalPages = computed(() => Math.ceil(total.value / pageSize))
+
+// Edit form
+const showEditForm = ref(false)
+const editingEventId = ref<number | null>(null)
+const editForm = ref({
+  comment: '' as string | null,
+  event_at: '' as string | null,
+})
+
+function typeClass(type: number): string {
+  switch (type) {
+    case 1: return 'bg-blue-100 text-blue-800'
+    case 2: return 'bg-purple-100 text-purple-800'
+    case 3: return 'bg-green-100 text-green-800'
+    case 4: return 'bg-yellow-100 text-yellow-800'
+    case 5: return 'bg-gray-100 text-gray-800'
+    default: return 'bg-gray-100 text-gray-800'
+  }
+}
+
+function formatDateTime(dateStr: string | null): string {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function toDatetimeLocal(dateStr: string | null): string {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+async function loadEvents() {
+  loading.value = true
+  try {
+    const params: Record<string, string | number> = {
+      skip: (currentPage.value - 1) * pageSize,
+      limit: pageSize,
+    }
+    if (search.value) params.search = search.value
+    if (typeFilter.value !== null) params.type = typeFilter.value
+
+    const result = await getAdminRecruitmentEvents(params)
+    events.value = result.items
+    total.value = result.total
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function openEdit(event: AdminRecruitmentEvent) {
+  editingEventId.value = event.id
+  editForm.value = {
+    comment: event.comment ?? '',
+    event_at: toDatetimeLocal(event.event_at),
+  }
+  showEditForm.value = true
+}
+
+async function handleEditSubmit() {
+  if (!editingEventId.value) return
+  loading.value = true
+  try {
+    const payload = {
+      comment: editForm.value.comment || null,
+      event_at: editForm.value.event_at ? new Date(editForm.value.event_at).toISOString() : null,
+    }
+    await updateAdminRecruitmentEvent(editingEventId.value, payload)
+    toast.success('Activité modifiée avec succès')
+    showEditForm.value = false
+    await loadEvents()
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleDelete(event: AdminRecruitmentEvent) {
+  const label = `l'activité « ${event.type_as_string} » de ${event.user_nickname ?? 'inconnu'}`
+  const ok = await confirm(`Supprimer ${label} ? Cette action est irréversible.`)
+  if (!ok) return
+  try {
+    await deleteAdminRecruitmentEvent(event.id)
+    toast.success('Activité supprimée avec succès')
+    await loadEvents()
+  } catch (e) {
+    toast.error(e)
+  }
+}
+
+function goToPage(page: number) {
+  if (page < 1 || page > totalPages.value) return
+  currentPage.value = page
+  loadEvents()
+}
+
+watch([search, typeFilter], () => {
+  currentPage.value = 1
+  loadEvents()
+})
+
+onMounted(loadEvents)
+</script>
+
+<template>
+  <div>
+    <AppBreadcrumb />
+
+    <!-- Search & Filters -->
+    <div class="flex flex-col sm:flex-row gap-3 mb-4">
+      <div class="relative flex-1">
+        <i class="fa-solid fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm"></i>
+        <input
+          :value="searchInput"
+          type="text"
+          class="input pl-9 w-full"
+          placeholder="Rechercher par pseudo du cadet..."
+          @input="searchInput = ($event.target as HTMLInputElement).value; onSearchInput()"
+        />
+      </div>
+      <select
+        :value="typeFilter ?? ''"
+        class="input w-full sm:w-48"
+        @change="typeFilter = ($event.target as HTMLSelectElement).value === '' ? null : Number(($event.target as HTMLSelectElement).value)"
+      >
+        <option value="">Tous les types</option>
+        <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
+    </div>
+
+    <!-- Edit form -->
+    <div v-if="showEditForm" class="card mb-6">
+      <h3 class="text-lg font-semibold mb-4">Modifier l'activité</h3>
+      <form class="space-y-4" @submit.prevent="handleEditSubmit">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="label">Date</label>
+            <input v-model="editForm.event_at" type="datetime-local" class="input" />
+          </div>
+          <div>
+            <label class="label">Commentaire</label>
+            <input v-model="editForm.comment" type="text" class="input" maxlength="255" />
+          </div>
+        </div>
+        <div class="flex justify-end space-x-3">
+          <button type="button" class="btn-secondary" @click="showEditForm = false">
+            <i class="fa-solid fa-xmark mr-1"></i>Annuler
+          </button>
+          <button type="submit" class="btn-primary" :disabled="loading">
+            <i class="fa-solid fa-floppy-disk mr-1"></i>{{ loading ? 'Enregistrement...' : 'Modifier' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Activities table -->
+    <div class="card overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b text-left">
+            <th class="p-2">Cadet</th>
+            <th class="p-2">Type</th>
+            <th class="p-2">Date</th>
+            <th class="p-2">Commentaire</th>
+            <th class="p-2">Validateur</th>
+            <th class="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="loading && !events.length">
+            <td colspan="6" class="p-4 text-center text-gray-500">Chargement...</td>
+          </tr>
+          <tr v-else-if="!events.length">
+            <td colspan="6" class="p-4 text-center text-gray-500">Aucune activité</td>
+          </tr>
+          <tr
+            v-for="event in events"
+            :key="event.id"
+            class="border-b hover:bg-gray-50"
+          >
+            <td class="p-2 font-medium">{{ event.user_nickname ?? '-' }}</td>
+            <td class="p-2">
+              <span
+                class="inline-block px-2 py-0.5 rounded-full text-xs font-medium"
+                :class="typeClass(event.type)"
+              >
+                {{ event.type_as_string }}
+              </span>
+            </td>
+            <td class="p-2 whitespace-nowrap">{{ formatDateTime(event.event_at) }}</td>
+            <td class="p-2 max-w-xs truncate" :title="event.comment ?? ''">
+              {{ event.comment ?? '-' }}
+            </td>
+            <td class="p-2">{{ event.validator_nickname ?? '-' }}</td>
+            <td class="p-2 whitespace-nowrap">
+              <button
+                class="text-veaf-600 hover:text-veaf-800 text-sm mr-3"
+                title="Modifier"
+                @click="openEdit(event)"
+              >
+                <i class="fa-solid fa-edit"></i>
+              </button>
+              <button
+                class="text-red-600 hover:text-red-800 text-sm"
+                title="Supprimer"
+                @click="handleDelete(event)"
+              >
+                <i class="fa-solid fa-trash"></i>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="totalPages > 1" class="flex items-center justify-between mt-4">
+      <span class="text-sm text-gray-600">
+        {{ total }} activité{{ total > 1 ? 's' : '' }}
+      </span>
+      <div class="flex items-center space-x-2">
+        <button
+          class="btn-secondary text-sm"
+          :disabled="currentPage <= 1"
+          @click="goToPage(currentPage - 1)"
+        >
+          <i class="fa-solid fa-chevron-left mr-1"></i>Précédent
+        </button>
+        <span class="text-sm text-gray-600">
+          Page {{ currentPage }} sur {{ totalPages }}
+        </span>
+        <button
+          class="btn-secondary text-sm"
+          :disabled="currentPage >= totalPages"
+          @click="goToPage(currentPage + 1)"
+        >
+          Suivant<i class="fa-solid fa-chevron-right ml-1"></i>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -74,6 +74,11 @@ onMounted(async () => {
         <div class="text-3xl font-bold text-veaf-500 mb-2">{{ stats?.menu_items ?? '-' }}</div>
         <div class="text-sm text-gray-900">Menu</div>
       </RouterLink>
+      <RouterLink to="/admin/activities" class="card text-center hover:shadow-md transition-shadow">
+        <div class="text-veaf-400 mb-2"><i class="fa-solid fa-clipboard-list text-2xl"></i></div>
+        <div class="text-3xl font-bold text-veaf-500 mb-2">{{ stats?.recruitment_events ?? '-' }}</div>
+        <div class="text-sm text-gray-900">Activités</div>
+      </RouterLink>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary by Sourcery

Add an admin-facing activities management feature for recruitment events, including listing, editing, and deleting events, and surface their count in admin statistics and dashboard.

New Features:
- Expose admin recruitment events API to list, filter, paginate, update, and delete recruitment events with appropriate authorization and side effects on cadet status.
- Add a frontend admin Activities view with search, type filtering, pagination, inline edit, and delete actions for recruitment events.
- Display recruitment events count and navigation card in the admin dashboard and route configuration.

Enhancements:
- Include recruitment events in the global admin statistics and API, and wire the new admin recruitment router into the main API router.
- Add a RecruitmentEvent factory and DTO schemas to support testing and admin-facing representations of recruitment events.

Tests:
- Add integration tests covering admin recruitment events listing, filtering, pagination, update, delete behaviors, and related authorization and cadet state changes.