### PR TITLE
detect frontend need to be reloaded

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Never cache version.json (used for new version detection)
+    location = /version.json {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,13 +3,16 @@ import { onMounted, onUnmounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useMenuStore } from '@/stores/menu'
 import { useHeaderStore } from '@/stores/header'
+import { useVersionCheck } from '@/composables/useVersionCheck'
 import AppHeader from '@/components/layout/AppHeader.vue'
 import AppFooter from '@/components/layout/AppFooter.vue'
 import ConfirmModal from '@/components/ui/ConfirmModal.vue'
+import VersionNotification from '@/components/ui/VersionNotification.vue'
 
 const auth = useAuthStore()
 const menu = useMenuStore()
 const headerStore = useHeaderStore()
+const { startVersionCheck, stopVersionCheck } = useVersionCheck()
 
 onMounted(async () => {
   if (auth.isAuthenticated) {
@@ -17,10 +20,12 @@ onMounted(async () => {
   }
   await menu.fetchMenu()
   headerStore.startPolling()
+  startVersionCheck()
 })
 
 onUnmounted(() => {
   headerStore.stopPolling()
+  stopVersionCheck()
 })
 </script>
 
@@ -33,4 +38,5 @@ onUnmounted(() => {
     <AppFooter />
   </div>
   <ConfirmModal />
+  <VersionNotification />
 </template>

--- a/frontend/src/components/ui/VersionNotification.vue
+++ b/frontend/src/components/ui/VersionNotification.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { useVersionCheck } from '@/composables/useVersionCheck'
+
+const { newVersionAvailable, reload } = useVersionCheck()
+</script>
+
+<template>
+  <Transition name="slide-up">
+    <div
+      v-if="newVersionAvailable"
+      class="fixed bottom-4 right-4 z-50 max-w-sm rounded-lg bg-veaf-700 text-white shadow-lg p-4 flex items-center gap-3"
+    >
+      <i class="fa-solid fa-arrow-rotate-right text-lg"></i>
+      <div class="flex-1">
+        <p class="text-sm font-medium">Une nouvelle version du site est disponible.</p>
+      </div>
+      <button
+        class="btn-primary text-sm px-3 py-1.5 rounded whitespace-nowrap"
+        @click="reload"
+      >
+        Recharger
+      </button>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: all 0.3s ease;
+}
+.slide-up-enter-from,
+.slide-up-leave-to {
+  opacity: 0;
+  transform: translateY(1rem);
+}
+</style>

--- a/frontend/src/composables/useVersionCheck.ts
+++ b/frontend/src/composables/useVersionCheck.ts
@@ -1,0 +1,39 @@
+import { ref } from 'vue'
+
+const CHECK_INTERVAL = 120_000 // 2 minutes
+const newVersionAvailable = ref(false)
+let timer: ReturnType<typeof setInterval> | null = null
+
+async function checkVersion() {
+  try {
+    const res = await fetch(`/version.json?t=${Date.now()}`)
+    if (!res.ok) return
+    const data = await res.json()
+    if (data.version && data.version !== __APP_VERSION__) {
+      newVersionAvailable.value = true
+    }
+  } catch {
+    // silently ignore network errors
+  }
+}
+
+export function useVersionCheck() {
+  function startVersionCheck() {
+    if (import.meta.env.DEV || timer !== null) return
+    checkVersion()
+    timer = setInterval(checkVersion, CHECK_INTERVAL)
+  }
+
+  function stopVersionCheck() {
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  function reload() {
+    window.location.reload()
+  }
+
+  return { newVersionAvailable, startVersionCheck, stopVersionCheck, reload }
+}

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/frontend/vite-plugin-version.ts
+++ b/frontend/vite-plugin-version.ts
@@ -1,0 +1,22 @@
+import { type Plugin } from 'vite'
+import { writeFileSync } from 'fs'
+import { resolve } from 'path'
+
+export function versionPlugin(): Plugin {
+  const version = new Date().toISOString().slice(0, 19)
+
+  return {
+    name: 'version-plugin',
+    config() {
+      return {
+        define: {
+          __APP_VERSION__: JSON.stringify(version),
+        },
+      }
+    },
+    writeBundle(options) {
+      const dir = options.dir ?? resolve('dist')
+      writeFileSync(resolve(dir, 'version.json'), JSON.stringify({ version }))
+    },
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
+import { versionPlugin } from './vite-plugin-version'
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), versionPlugin()],
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary by Sourcery

Add automatic frontend version detection to notify users when a new deployment is available and prompt them to reload the app.

New Features:
- Introduce a version checking composable that periodically polls a build-generated version.json and exposes reload controls when a new version is detected.
- Display a user-facing notification banner when a newer frontend version is available, allowing users to reload the page from the UI.

Enhancements:
- Generate and embed a build-time application version via a custom Vite plugin and expose it as a global constant for runtime comparison.
- Update the main app lifecycle to start and stop periodic version checks alongside existing polling behavior.
- Adjust Nginx configuration to disable caching for version.json so clients always see the latest deployed version information.

Build:
- Add a custom Vite plugin that defines a compile-time __APP_VERSION__ constant and writes a version.json file into the build output directory.