### PR TITLE
refresh calendar after event added or updated

### DIFF
--- a/frontend/src/stores/calendar.ts
+++ b/frontend/src/stores/calendar.ts
@@ -32,5 +32,10 @@ export const useCalendarStore = defineStore('calendar', () => {
     }
   }
 
-  return { events, currentRange, myEvents, tasks, fetchEvents, fetchMyEvents, fetchTasks }
+  function invalidate() {
+    currentRange.value = { from: '', to: '' }
+    myEvents.value = []
+  }
+
+  return { events, currentRange, myEvents, tasks, fetchEvents, fetchMyEvents, fetchTasks, invalidate }
 })

--- a/frontend/src/views/EventEditView.vue
+++ b/frontend/src/views/EventEditView.vue
@@ -6,6 +6,7 @@ import { getModules } from '@/api/modules'
 import { getServers } from '@/api/servers'
 import { uploadFile } from '@/api/files'
 import { useToast } from '@/composables/useToast'
+import { useCalendarStore } from '@/stores/calendar'
 import MarkdownEditor from '@/components/ui/MarkdownEditor.vue'
 import MultiSelect from '@/components/ui/MultiSelect.vue'
 import type { MultiSelectOption } from '@/components/ui/MultiSelect.vue'
@@ -18,6 +19,7 @@ import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
 const route = useRoute()
 const router = useRouter()
 const toast = useToast()
+const calendar = useCalendarStore()
 
 const id = route.params.id ? Number(route.params.id) : null
 const isEdit = computed(() => id !== null)
@@ -163,10 +165,12 @@ async function handleSubmit() {
   try {
     if (isEdit.value && id) {
       await updateEvent(id, form.value)
+      calendar.invalidate()
       toast.success('Événement modifié')
       router.push(`/calendar/${id}`)
     } else {
       const event = await createEvent(form.value)
+      calendar.invalidate()
       toast.success('Événement créé')
       router.push(`/calendar/${event.id}`)
     }


### PR DESCRIPTION
## Summary by Sourcery

Invalidate and refresh the calendar view after creating or updating an event to ensure displayed data stays in sync with recent changes.

Enhancements:
- Add an invalidate helper to the calendar store to reset the current range and cached events.
- Trigger calendar store invalidation after event creation or update in the event edit view.