### PR TITLE
fix page destination from landing page

### DIFF
--- a/frontend/src/components/home/ModuleCard.vue
+++ b/frontend/src/components/home/ModuleCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { Module } from '@/types/module'
+import { MODULE_TYPE_TO_TAB } from '@/constants/modules'
 
 const props = defineProps<{
   module: Module
@@ -13,10 +14,15 @@ const imageSrc = computed(() => {
 })
 
 const displayText = computed(() => props.module.code.toUpperCase())
+
+const rosterLink = computed(() => {
+  const tab = MODULE_TYPE_TO_TAB[props.module.type]
+  return tab ? `/roster?tab=${tab}&moduleId=${props.module.id}` : '/roster'
+})
 </script>
 
 <template>
-  <RouterLink to="/roster" class="block group">
+  <RouterLink :to="rosterLink" class="block group">
     <div class="relative overflow-hidden rounded">
       <img
         v-if="imageSrc"

--- a/frontend/src/constants/modules.ts
+++ b/frontend/src/constants/modules.ts
@@ -39,6 +39,11 @@ export const TAB_TO_MODULE_TYPE: Record<string, number> = {
   specials: MODULE_TYPE_SPECIAL,
 }
 
+// Module type → tab key (reverse mapping)
+export const MODULE_TYPE_TO_TAB: Record<number, string> = Object.fromEntries(
+  Object.entries(TAB_TO_MODULE_TYPE).map(([tab, type]) => [type, tab]),
+)
+
 // Module type → FontAwesome icon class
 export function moduleTypeIcon(moduleType: number | null): string {
   if (moduleType === MODULE_TYPE_HELICOPTER) return 'fa-solid fa-helicopter'

--- a/frontend/src/views/RosterView.vue
+++ b/frontend/src/views/RosterView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { getRosterStats } from '@/api/roster'
 import type { RosterStats } from '@/api/roster'
 import RosterPilotsList from '@/components/roster/RosterPilotsList.vue'
@@ -9,6 +10,7 @@ import { TAB_TO_MODULE_TYPE } from '@/constants/modules'
 import { useAuthStore } from '@/stores/auth'
 import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
 
+const route = useRoute()
 const authStore = useAuthStore()
 
 const group = ref('all')
@@ -52,6 +54,14 @@ function changeTab(newTab: string) {
 }
 
 onMounted(async () => {
+  const queryTab = route.query.tab as string | undefined
+  const queryModuleId = route.query.moduleId as string | undefined
+  if (queryTab && queryTab in tabToModuleType) {
+    tab.value = queryTab
+  }
+  if (queryModuleId) {
+    selectedModuleId.value = Number(queryModuleId)
+  }
   await loadStats()
   loading.value = false
 })


### PR DESCRIPTION
## Summary by Sourcery

Preserve and restore roster view context based on module selection from the landing page, wiring module cards to deep-link into the appropriate roster tab and module.

New Features:
- Allow direct navigation from module cards to the roster view with preselected tab and module via query parameters.

Bug Fixes:
- Ensure the roster view initializes its active tab and selected module from URL query parameters when provided.

Enhancements:
- Introduce a reverse mapping from tab keys to module types to support generating roster deep links from module metadata.