### PR TITLE
fix VIRTUAL_PORT for maildev

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - staging
     environment:
       VIRTUAL_HOST: maildev.${VIRTUAL_HOST:-veaf.org}
+      VIRTUAL_PORT: 1080
       LETSENCRYPT_HOST: maildev.${VIRTUAL_HOST:-veaf.org}
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL:-}
       MAILDEV_WEB_USER: ${MAILDEV_WEB_USER:-veaf}


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Configure the Maildev container to use virtual port 1080 in the docker-compose deployment setup.