### PR TITLE
add discord channel support link

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -23,6 +23,7 @@ API_TEAMSPEAK_URL=serverquery://ts.veaf.org:10011/?server_port=9987
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 DISCORD_REDIRECT_URI=http://veaf.localhost/auth/discord/callback
+DISCORD_SUPPORT_URL=
 
 # reCAPTCHA v3
 RECAPTCHA_SECRET_KEY=

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     DISCORD_CLIENT_ID: str = ""
     DISCORD_CLIENT_SECRET: str = ""
     DISCORD_REDIRECT_URI: str = "http://localhost/auth/discord/callback"
+    DISCORD_SUPPORT_URL: str = ""
 
     # reCAPTCHA
     RECAPTCHA_SECRET_KEY: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,4 +65,9 @@ async def health():
 
 @app.get("/api")
 async def api_info():
-    return {"title": app.title, "version": app.version, "description": app.description}
+    return {
+        "title": app.title,
+        "version": app.version,
+        "description": app.description,
+        "discord_support_url": settings.DISCORD_SUPPORT_URL or None,
+    }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,6 +7,7 @@ import { useVersionCheck } from '@/composables/useVersionCheck'
 import AppHeader from '@/components/layout/AppHeader.vue'
 import AppFooter from '@/components/layout/AppFooter.vue'
 import ConfirmModal from '@/components/ui/ConfirmModal.vue'
+import DiscordSupportModal from '@/components/ui/DiscordSupportModal.vue'
 import VersionNotification from '@/components/ui/VersionNotification.vue'
 
 const auth = useAuthStore()
@@ -38,5 +39,6 @@ onUnmounted(() => {
     <AppFooter />
   </div>
   <ConfirmModal />
+  <DiscordSupportModal />
   <VersionNotification />
 </template>

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -4,17 +4,22 @@ import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useMenuStore } from '@/stores/menu'
 import apiClient from '@/api/client'
+import { useDiscordSupport } from '@/composables/useDiscordSupport'
 import NavMenu from './NavMenu.vue'
 
 const auth = useAuthStore()
 const menu = useMenuStore()
 const frontendVersion = __APP_SEMVER__
 const backendVersion = ref('')
+const { discordUrl, setUrl: setDiscordUrl, open: openDiscordSupport } = useDiscordSupport()
 
 async function fetchBackendVersion() {
   try {
     const { data } = await apiClient.get('/')
     backendVersion.value = data.version
+    if (data.discord_support_url) {
+      setDiscordUrl(data.discord_support_url)
+    }
   } catch {
     // silently ignore
   }
@@ -115,6 +120,13 @@ async function handleLogout() {
                 >
                   <i class="fa-solid fa-gear mr-1"></i>Administration
                 </RouterLink>
+                <button
+                  v-if="discordUrl"
+                  @click="openDiscordSupport(); closeUserDropdown()"
+                  class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:text-veaf-600 hover:bg-gray-50"
+                >
+                  <i class="fa-brands fa-discord mr-1"></i>Support Discord
+                </button>
                 <div class="border-t border-gray-200 my-1"></div>
                 <button
                   @click="handleLogout"
@@ -158,6 +170,13 @@ async function handleLogout() {
             >
               <i class="fa-solid fa-gear mr-1"></i>Administration
             </RouterLink>
+            <button
+              v-if="discordUrl"
+              @click="openDiscordSupport(); mobileMenuOpen = false"
+              class="block w-full text-left px-3 py-2 text-sm text-white hover:text-white hover:bg-white/10 rounded-md"
+            >
+              <i class="fa-brands fa-discord mr-1"></i>Support Discord
+            </button>
             <button
               @click="handleLogout"
               class="block w-full text-left px-3 py-2 text-sm text-white/80 hover:text-white hover:bg-white/10 rounded-md"

--- a/frontend/src/components/ui/DiscordSupportModal.vue
+++ b/frontend/src/components/ui/DiscordSupportModal.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { useDiscordSupport } from '@/composables/useDiscordSupport'
+
+const { visible, discordUrl, close } = useDiscordSupport()
+
+function openDiscord() {
+  window.open(discordUrl.value, '_blank')
+  close()
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    close()
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="visible"
+        class="fixed inset-0 z-50 flex items-center justify-center"
+        @keydown="onKeydown"
+      >
+        <!-- Backdrop -->
+        <div
+          class="absolute inset-0 bg-black/50"
+          @click="close"
+        />
+
+        <!-- Modal panel -->
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="discord-support-title"
+          aria-describedby="discord-support-message"
+          class="relative bg-white rounded-lg shadow-lg border border-gray-200 p-6 max-w-md w-full mx-4"
+        >
+          <div class="flex items-start space-x-4">
+            <div class="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-100 flex items-center justify-center">
+              <i class="fa-brands fa-discord text-indigo-600 text-xl"></i>
+            </div>
+
+            <div class="flex-1">
+              <h3 id="discord-support-title" class="text-lg font-semibold text-gray-900">
+                Support Discord
+              </h3>
+              <p id="discord-support-message" class="mt-2 text-sm text-gray-600">
+                Pour toute question ou besoin d'aide, rejoignez notre canal Discord.
+                Vous pourrez y échanger avec les membres de la communauté VEAF.
+              </p>
+            </div>
+          </div>
+
+          <div class="mt-6 flex justify-end space-x-3">
+            <button class="btn-secondary" @click="close">
+              <i class="fa-solid fa-xmark mr-1"></i>Fermer
+            </button>
+            <button
+              class="text-white font-medium py-2 px-4 rounded-md text-sm transition-colors hover:opacity-90"
+              style="background-color: #5865F2"
+              @click="openDiscord"
+            >
+              <i class="fa-brands fa-discord mr-1"></i>Rejoindre le Discord
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/frontend/src/composables/useDiscordSupport.ts
+++ b/frontend/src/composables/useDiscordSupport.ts
@@ -1,0 +1,22 @@
+import { ref } from 'vue'
+
+const visible = ref(false)
+const discordUrl = ref('')
+
+export function useDiscordSupport() {
+  function setUrl(url: string) {
+    discordUrl.value = url
+  }
+
+  function open() {
+    if (discordUrl.value) {
+      visible.value = true
+    }
+  }
+
+  function close() {
+    visible.value = false
+  }
+
+  return { visible, discordUrl, setUrl, open, close }
+}

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -4,6 +4,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
 import { getDiscordAuthUrl } from '@/api/auth'
+import { useDiscordSupport } from '@/composables/useDiscordSupport'
 
 const auth = useAuthStore()
 const router = useRouter()
@@ -15,6 +16,7 @@ const password = ref('')
 const loading = ref(false)
 const discordLoading = ref(false)
 const showLocalLogin = ref(false)
+const { discordUrl, open: openDiscordSupport } = useDiscordSupport()
 
 async function handleLogin() {
   loading.value = true
@@ -112,6 +114,16 @@ async function handleDiscordLogin() {
           </p>
         </div>
       </template>
+
+      <div v-if="discordUrl" class="mt-6 pt-4 border-t border-gray-200 text-center">
+        <button
+          type="button"
+          class="text-sm text-gray-500 hover:text-indigo-600 transition-colors"
+          @click="openDiscordSupport()"
+        >
+          <i class="fa-brands fa-discord mr-1"></i>Besoin d'aide ? Contactez-nous sur Discord
+        </button>
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
 import { getDiscordAuthUrl } from '@/api/auth'
+import { useDiscordSupport } from '@/composables/useDiscordSupport'
 
 const auth = useAuthStore()
 const router = useRouter()
@@ -15,6 +16,7 @@ const password = ref('')
 const passwordConfirm = ref('')
 const loading = ref(false)
 const discordLoading = ref(false)
+const { discordUrl, open: openDiscordSupport } = useDiscordSupport()
 
 async function handleRegister() {
   if (password.value !== passwordConfirm.value) {
@@ -106,6 +108,16 @@ async function handleDiscordRegister() {
           Déjà un compte ?
           <RouterLink to="/login" class="text-veaf-600 hover:text-veaf-800">Se connecter</RouterLink>
         </p>
+      </div>
+
+      <div v-if="discordUrl" class="mt-6 pt-4 border-t border-gray-200 text-center">
+        <button
+          type="button"
+          class="text-sm text-gray-500 hover:text-indigo-600 transition-colors"
+          @click="openDiscordSupport()"
+        >
+          <i class="fa-brands fa-discord mr-1"></i>Besoin d'aide ? Contactez-nous sur Discord
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary by Sourcery

Add configurable Discord support integration across backend and frontend to surface a support Discord link in the UI when available.

New Features:
- Expose a configurable Discord support URL from the backend API metadata endpoint.
- Introduce a global Discord support modal and composable to manage support link visibility and behavior.
- Add Discord support entry points in the header, login, and registration views when a support URL is configured.