### PR TITLE
send email on registration and password lost

### DIFF
--- a/backend/.env.dist
+++ b/backend/.env.dist
@@ -7,13 +7,14 @@ JWT_ALGORITHM=HS256
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15
 JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 
-# Email
+# Email (defaults configured for MailDev in docker-compose)
 MAIL_FROM=noreply@veaf.org
-MAIL_SERVER=localhost
-MAIL_PORT=587
+MAIL_SERVER=maildev
+MAIL_PORT=1025
 MAIL_USERNAME=
 MAIL_PASSWORD=
-MAIL_TLS=true
+MAIL_STARTTLS=false
+MAIL_SSL_TLS=false
 
 # External APIs
 API_DCSSERVERBOT_URL=http://dcs.veaf.org:9876

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Response, Cookie, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, Cookie, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,6 +21,7 @@ from app.schemas.auth import (
     ResetPasswordRequest,
     TokenResponse,
 )
+from app.services.email import send_password_reset_email, send_welcome_email
 from app.utils.cache import discord_oauth_states
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -50,7 +51,7 @@ async def login(data: LoginRequest, response: Response, db: AsyncSession = Depen
 
 
 @router.post("/register", response_model=TokenResponse)
-async def register(data: RegisterRequest, response: Response, db: AsyncSession = Depends(get_db)):
+async def register(data: RegisterRequest, response: Response, background_tasks: BackgroundTasks, db: AsyncSession = Depends(get_db)):
     # Check uniqueness
     existing = await db.execute(select(User).where((User.email == data.email) | (User.nickname == data.nickname)))
     if existing.scalar_one_or_none():
@@ -69,6 +70,8 @@ async def register(data: RegisterRequest, response: Response, db: AsyncSession =
     db.add(user)
     await db.commit()
     await db.refresh(user)
+
+    background_tasks.add_task(send_welcome_email, user.email, user.nickname)
 
     access_token = create_access_token(user.id, user.get_roles_list())
     refresh_token = create_refresh_token(user.id)
@@ -121,7 +124,7 @@ async def logout(response: Response):
 
 
 @router.post("/reset-password")
-async def reset_password(data: ResetPasswordRequest, db: AsyncSession = Depends(get_db)):
+async def reset_password(data: ResetPasswordRequest, background_tasks: BackgroundTasks, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(User).where(User.email == data.email))
     user = result.scalar_one_or_none()
 
@@ -129,14 +132,12 @@ async def reset_password(data: ResetPasswordRequest, db: AsyncSession = Depends(
         # Don't reveal if email exists
         return {"detail": "If this email exists, a reset link has been sent."}
 
-    import secrets
-
     token = secrets.token_urlsafe(32)
     user.password_request_token = token
     user.password_request_expired_at = datetime.now(UTC) + timedelta(hours=24)
     await db.commit()
 
-    # TODO: Send email with reset link
+    background_tasks.add_task(send_password_reset_email, user.email, user.nickname or user.email, token)
     return {"detail": "If this email exists, a reset link has been sent."}
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,11 +13,12 @@ class Settings(BaseSettings):
 
     # Email
     MAIL_FROM: str = "noreply@veaf.org"
-    MAIL_SERVER: str = "localhost"
-    MAIL_PORT: int = 587
+    MAIL_SERVER: str = "maildev"
+    MAIL_PORT: int = 1025
     MAIL_USERNAME: str = ""
     MAIL_PASSWORD: str = ""
-    MAIL_TLS: bool = True
+    MAIL_STARTTLS: bool = False
+    MAIL_SSL_TLS: bool = False
 
     # External APIs
     API_DCSSERVERBOT_URL: str = "http://dcs.veaf.org:9876"

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,76 @@
+import logging
+
+from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _get_mail_config() -> ConnectionConfig:
+    return ConnectionConfig(
+        MAIL_USERNAME=settings.MAIL_USERNAME,
+        MAIL_PASSWORD=settings.MAIL_PASSWORD,
+        MAIL_FROM=settings.MAIL_FROM,
+        MAIL_PORT=settings.MAIL_PORT,
+        MAIL_SERVER=settings.MAIL_SERVER,
+        MAIL_STARTTLS=settings.MAIL_STARTTLS,
+        MAIL_SSL_TLS=settings.MAIL_SSL_TLS,
+        USE_CREDENTIALS=bool(settings.MAIL_USERNAME),
+    )
+
+
+_fm: FastMail | None = None
+
+
+def _get_fastmail() -> FastMail:
+    global _fm
+    if _fm is None:
+        _fm = FastMail(_get_mail_config())
+    return _fm
+
+
+async def send_welcome_email(email: str, nickname: str) -> None:
+    """Send welcome email after registration."""
+    html = f"""\
+<h2>Bienvenue sur le site de la VEAF, {nickname} !</h2>
+<p>Votre compte a bien été créé.</p>
+<p>Vous pouvez dès à présent vous connecter sur <a href="{settings.APP_URL}">{settings.APP_URL}</a>.</p>
+<p>À bientôt sur nos serveurs !</p>
+<p>L'équipe VEAF</p>"""
+
+    message = MessageSchema(
+        subject="Bienvenue sur le site de la VEAF",
+        recipients=[email],
+        body=html,
+        subtype=MessageType.html,
+    )
+    try:
+        await _get_fastmail().send_message(message)
+    except Exception:
+        logger.exception("Failed to send welcome email to %s", email)
+
+
+async def send_password_reset_email(email: str, nickname: str, token: str) -> None:
+    """Send password reset link."""
+    reset_url = f"{settings.APP_URL}/reset-password?token={token}"
+    html = f"""\
+<h2>Réinitialisation de votre mot de passe</h2>
+<p>Bonjour {nickname},</p>
+<p>Vous avez demandé la réinitialisation de votre mot de passe.</p>
+<p>Cliquez sur le lien ci-dessous pour choisir un nouveau mot de passe :</p>
+<p><a href="{reset_url}">{reset_url}</a></p>
+<p>Ce lien est valable pendant 24 heures.</p>
+<p>Si vous n'êtes pas à l'origine de cette demande, ignorez cet email.</p>
+<p>L'équipe VEAF</p>"""
+
+    message = MessageSchema(
+        subject="Réinitialisation de votre mot de passe - VEAF",
+        recipients=[email],
+        body=html,
+        subtype=MessageType.html,
+    )
+    try:
+        await _get_fastmail().send_message(message)
+    except Exception:
+        logger.exception("Failed to send password reset email to %s", email)

--- a/backend/tests/integration/api/test_auth.py
+++ b/backend/tests/integration/api/test_auth.py
@@ -14,15 +14,38 @@ from tests.factories import UserFactory
 
 @pytest.mark.asyncio
 async def test_register(client: AsyncClient):
-    response = await client.post("/api/auth/register", json={
-        "email": "test@veaf.org",
-        "password": "Password123!",
-        "nickname": "TestPilot",
-    })
+    # WHEN
+    with patch("app.services.email._get_fastmail") as mock_fm:
+        mock_fm.return_value.send_message = AsyncMock()
+        response = await client.post("/api/auth/register", json={
+            "email": "test@veaf.org",
+            "password": "Password123!",
+            "nickname": "TestPilot",
+        })
+
+    # THEN
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data
     assert data["token_type"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_reset_password_sends_email(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    user = UserFactory(email="reset@veaf.org", nickname="ResetUser")
+    db_session.add(user)
+    await db_session.flush()
+
+    # WHEN
+    with patch("app.services.email._get_fastmail") as mock_fm:
+        mock_fm.return_value.send_message = AsyncMock()
+        response = await client.post("/api/auth/reset-password", json={"email": "reset@veaf.org"})
+
+    # THEN
+    assert response.status_code == 200
+    await db_session.refresh(user)
+    assert user.password_request_token is not None
 
 
 @pytest.mark.asyncio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,17 @@ services:
       - backend
       - frontend
 
+  maildev:
+    image: maildev/maildev:2.1.0
+    environment:
+      MAILDEV_SMTP_PORT: 1025
+      MAILDEV_WEB_PORT: 1080
+      VIRTUAL_HOST: maildev.${VIRTUAL_HOST:-veaf.localhost}
+      VIRTUAL_PORT: 1080
+    networks:
+      - default
+      - webproxy
+
   postgres:
     image: postgres:16-alpine
     environment:


### PR DESCRIPTION
## Summary by Sourcery

Send transactional emails on user registration and password reset and wire up supporting infrastructure.

New Features:
- Send a welcome email in the background when a user registers.
- Send a password reset email with a time-limited token when a password reset is requested.

Enhancements:
- Introduce a reusable email service module based on FastMail and application settings.
- Queue email sending via FastAPI background tasks to avoid blocking auth endpoints.

Build:
- Add a MailDev service to docker-compose for local SMTP testing and adjust default mail configuration to use it.

Tests:
- Extend auth integration tests to verify that registration and password reset trigger email sending behavior via mocked FastMail.