### PR TITLE
improve import-yaml command

### DIFF
--- a/backend/app/commands/database.py
+++ b/backend/app/commands/database.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import typer
+from rich import print as rprint
 
 database_app = typer.Typer(help="Database management commands", no_args_is_help=True)
 
@@ -31,6 +32,37 @@ async def _exec_sql(statement) -> None:
     await engine.dispose()
 
 
+async def _has_data() -> bool:
+    """Check if the user table has any data."""
+    from sqlalchemy import text
+
+    from app.database import engine
+
+    try:
+        async with engine.begin() as conn:
+            result = await conn.execute(text('SELECT COUNT(*) FROM "user"'))
+            count = result.scalar()
+            return count > 0
+    except Exception:
+        return False
+    finally:
+        await engine.dispose()
+
+
+def _run_migrations() -> None:
+    """Drop alembic_version and run alembic upgrade head."""
+    import subprocess
+
+    from sqlalchemy import text
+
+    asyncio.run(_exec_sql(text("DROP TABLE IF EXISTS alembic_version")))
+    result = subprocess.run(["alembic", "upgrade", "head"], capture_output=True, text=True)
+    if result.returncode != 0:
+        rprint(f"[bold red]Migration failed: {result.stderr}[/bold red]")
+        raise typer.Exit(1)
+    rprint("[bold green]Tables created (via migrations).[/bold green]")
+
+
 async def _load_fixtures() -> None:
     from fixtures import load_all
 
@@ -42,40 +74,33 @@ def drop() -> None:
     """Drop all database tables."""
     typer.confirm("This will DROP all tables. Continue?", abort=True)
     asyncio.run(_drop_tables())
-    typer.echo("All tables dropped.")
+    rprint("[bold green]All tables dropped.[/bold green]")
 
 
 @database_app.command()
 def create() -> None:
     """Create all database tables from models."""
     asyncio.run(_create_tables())
-    typer.echo("All tables created.")
+    rprint("[bold green]All tables created.[/bold green]")
 
 
 @database_app.command()
 def fixtures(
-    migrations: bool = typer.Option(False, "--migrations", help="Use Alembic migrations instead of create_all"),
+    migrations: bool = typer.Option(True, "--migrations/--no-migrations", help="Use Alembic migrations (default) or create_all"),
     data: bool = typer.Option(True, "--data/--no-data", help="Load seed data after creating schema"),
 ) -> None:
     """Drop tables, recreate schema, and optionally load seed data."""
+    if asyncio.run(_has_data()):
+        typer.confirm("Users already exist in the database. This will DROP all data. Continue?", abort=True)
     asyncio.run(_drop_tables())
-    typer.echo("Tables dropped.")
+    rprint("[bold green]Tables dropped.[/bold green]")
     if migrations:
-        import subprocess
-
-        from sqlalchemy import text
-
-        asyncio.run(_exec_sql(text("DROP TABLE IF EXISTS alembic_version")))
-        result = subprocess.run(["alembic", "upgrade", "head"], capture_output=True, text=True)
-        if result.returncode != 0:
-            typer.echo(f"Migration failed: {result.stderr}", err=True)
-            raise typer.Exit(1)
-        typer.echo("Tables created (via migrations).")
+        _run_migrations()
     else:
         asyncio.run(_create_tables())
-        typer.echo("Tables created.")
+        rprint("[bold yellow]Tables created (without migration tracking).[/bold yellow]")
     if data:
         asyncio.run(_load_fixtures())
-        typer.echo("Fixtures loaded.")
+        rprint("[bold green]Fixtures loaded.[/bold green]")
     else:
-        typer.echo("Seed data skipped.")
+        rprint("Seed data skipped.")

--- a/backend/app/commands/maintenance.py
+++ b/backend/app/commands/maintenance.py
@@ -4,41 +4,38 @@ import os
 import typer
 from rich import print as rprint
 
+from app.commands.database import _create_tables, _drop_tables, _has_data, _run_migrations
 from app.config import settings
 
 maintenance_app = typer.Typer(help="Maintenance commands", no_args_is_help=True)
 
 
-async def _drop_tables() -> None:
-    import app.models  # noqa: F401
-    from app.database import Base, engine
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-    await engine.dispose()
-
-
-async def _create_tables() -> None:
-    import app.models  # noqa: F401
-    from app.database import Base, engine
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    await engine.dispose()
-
-
 @maintenance_app.command("import-yaml")
 def import_yaml(
     filepath: str = typer.Option("var/website.yml", help="Path to the YAML fixture file"),
+    migrations: bool = typer.Option(True, "--migrations/--no-migrations", help="Use Alembic migrations (default) or create_all"),
 ) -> None:
     """Drop tables, recreate schema, and import data from Symfony YAML export."""
-    typer.confirm("This will DROP all tables and import from YAML. Continue?", abort=True)
+    if not os.path.isfile(filepath):
+        rprint(f"[bold red]File not found: {filepath}[/bold red]")
+        raise typer.Exit(1)
+
+    if asyncio.run(_has_data()):
+        typer.confirm("Users already exist in the database. This will DROP all data and import from YAML. Continue?", abort=True)
+    else:
+        typer.confirm("This will DROP all tables and import from YAML. Continue?", abort=True)
     asyncio.run(_drop_tables())
-    typer.echo("Tables dropped.")
-    asyncio.run(_create_tables())
-    typer.echo("Tables created.")
+    rprint("[bold green]Tables dropped.[/bold green]")
+    if migrations:
+        _run_migrations()
+    else:
+        asyncio.run(_create_tables())
+        rprint("[bold yellow]Tables created (without migration tracking).[/bold yellow]")
     asyncio.run(_import_from_yaml(filepath))
-    typer.echo("Import complete.")
+    rprint("[bold green]Import complete.[/bold green]")
+
+    rprint(f"\n[bold yellow]Warning: remember to delete the import file to avoid data leaks:[/bold yellow]")
+    rprint(f"[bold cyan]   rm {filepath}[/bold cyan]\n")
 
 
 async def _import_from_yaml(filepath: str) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Improve database management and maintenance commands by reusing migration logic, adding safety checks, and enhancing CLI output for table and data operations.

New Features:
- Add a reusable helper to run Alembic migrations and report failures via rich-formatted output.
- Introduce a safety check that detects existing user data before dropping tables in fixtures and YAML import commands, requiring explicit confirmation.
- Allow the maintenance import-yaml command to optionally use Alembic migrations instead of direct table creation and warn users to delete the import file after use.

Enhancements:
- Unify table creation and migration logic between database and maintenance commands to reduce duplication.
- Switch database and maintenance command status messages from plain Typer echo to rich-formatted output for clearer CLI feedback.