### PR TITLE
add templates for emails

### DIFF
--- a/backend/app/commands/email.py
+++ b/backend/app/commands/email.py
@@ -9,18 +9,16 @@ from app.config import settings
 email_app = typer.Typer(help="Email commands", no_args_is_help=True)
 
 
-async def _send(to: str, subject: str, body: str) -> None:
-    from fastapi_mail import MessageSchema, MessageType
+async def _send_with_template(to: str, subject: str, body: str, template: str) -> None:
+    from app.services.email import send_email_with_template
 
-    from app.services.email import _get_fastmail
+    template_vars: dict[str, str] = {}
+    if template == "register":
+        template_vars = {"nickname": "Pilote"}
+    elif template == "reset_password":
+        template_vars = {"nickname": "Pilote", "reset_url": f"{settings.APP_URL}/reset-password?token=test-token"}
 
-    message = MessageSchema(
-        subject=subject,
-        recipients=[to],
-        body=body,
-        subtype=MessageType.html,
-    )
-    await _get_fastmail().send_message(message)
+    await send_email_with_template(to=to, subject=subject, template=template, body=body, template_vars=template_vars)
 
 
 @email_app.command("check")
@@ -63,11 +61,12 @@ def send(
     to: str = typer.Option(..., "--to", help="Recipient email address"),
     subject: str = typer.Option("Test VEAF", "--subject", help="Email subject"),
     body: str = typer.Option("Ceci est un email de test.", "--body", help="Email body (HTML supported)"),
+    template: str = typer.Option("default", "--template", help="Template name: default, register, reset_password"),
 ) -> None:
-    """Send a test email."""
-    rprint(f"[bold]Sending email to {to}...[/bold]")
+    """Send a test email using a template."""
+    rprint(f"[bold]Sending email to {to} (template: {template})...[/bold]")
     try:
-        asyncio.run(_send(to, subject, body))
+        asyncio.run(_send_with_template(to, subject, body, template))
         rprint(f"[bold green]OK[/bold green] — Email sent to {to}.")
     except Exception as e:
         rprint(f"[bold red]Error[/bold red] — {e}")

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,10 +1,14 @@
 import logging
+from datetime import UTC, datetime
+from pathlib import Path
 
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
 
 from app.config import settings
 
 logger = logging.getLogger(__name__)
+
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates" / "email"
 
 
 def _get_mail_config() -> ConnectionConfig:
@@ -17,6 +21,7 @@ def _get_mail_config() -> ConnectionConfig:
         MAIL_STARTTLS=settings.MAIL_STARTTLS,
         MAIL_SSL_TLS=settings.MAIL_SSL_TLS,
         USE_CREDENTIALS=bool(settings.MAIL_USERNAME),
+        TEMPLATE_FOLDER=TEMPLATE_DIR,
     )
 
 
@@ -30,23 +35,20 @@ def _get_fastmail() -> FastMail:
     return _fm
 
 
+def _base_template_vars() -> dict:
+    return {"app_url": settings.APP_URL, "year": datetime.now(UTC).year}
+
+
 async def send_welcome_email(email: str, nickname: str) -> None:
     """Send welcome email after registration."""
-    html = f"""\
-<h2>Bienvenue sur le site de la VEAF, {nickname} !</h2>
-<p>Votre compte a bien été créé.</p>
-<p>Vous pouvez dès à présent vous connecter sur <a href="{settings.APP_URL}">{settings.APP_URL}</a>.</p>
-<p>À bientôt sur nos serveurs !</p>
-<p>L'équipe VEAF</p>"""
-
     message = MessageSchema(
         subject="Bienvenue sur le site de la VEAF",
         recipients=[email],
-        body=html,
+        template_body={**_base_template_vars(), "nickname": nickname},
         subtype=MessageType.html,
     )
     try:
-        await _get_fastmail().send_message(message)
+        await _get_fastmail().send_message(message, template_name="register.html")
     except Exception:
         logger.exception("Failed to send welcome email to %s", email)
 
@@ -54,23 +56,33 @@ async def send_welcome_email(email: str, nickname: str) -> None:
 async def send_password_reset_email(email: str, nickname: str, token: str) -> None:
     """Send password reset link."""
     reset_url = f"{settings.APP_URL}/reset-password?token={token}"
-    html = f"""\
-<h2>Réinitialisation de votre mot de passe</h2>
-<p>Bonjour {nickname},</p>
-<p>Vous avez demandé la réinitialisation de votre mot de passe.</p>
-<p>Cliquez sur le lien ci-dessous pour choisir un nouveau mot de passe :</p>
-<p><a href="{reset_url}">{reset_url}</a></p>
-<p>Ce lien est valable pendant 24 heures.</p>
-<p>Si vous n'êtes pas à l'origine de cette demande, ignorez cet email.</p>
-<p>L'équipe VEAF</p>"""
-
     message = MessageSchema(
         subject="Réinitialisation de votre mot de passe - VEAF",
         recipients=[email],
-        body=html,
+        template_body={**_base_template_vars(), "nickname": nickname, "reset_url": reset_url},
         subtype=MessageType.html,
     )
     try:
-        await _get_fastmail().send_message(message)
+        await _get_fastmail().send_message(message, template_name="reset_password.html")
     except Exception:
         logger.exception("Failed to send password reset email to %s", email)
+
+
+async def send_email_with_template(
+    to: str,
+    subject: str,
+    template: str = "default",
+    body: str = "",
+    template_vars: dict | None = None,
+) -> None:
+    """Send an email using a named template."""
+    context = {**_base_template_vars(), "body": body}
+    if template_vars:
+        context.update(template_vars)
+    message = MessageSchema(
+        subject=subject,
+        recipients=[to],
+        template_body=context,
+        subtype=MessageType.html,
+    )
+    await _get_fastmail().send_message(message, template_name=f"{template}.html")

--- a/backend/app/templates/email/default.html
+++ b/backend/app/templates/email/default.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}VEAF{% endblock %}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f8;font-family:Arial,Helvetica,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f6f8;">
+    <tr>
+      <td align="center" style="padding:24px 16px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;border-collapse:collapse;">
+          <!-- Header -->
+          <tr>
+            <td style="background-color:#2fa4e7;padding:28px 24px;text-align:center;border-radius:8px 8px 0 0;">
+              <h1 style="margin:0;font-size:28px;font-weight:bold;color:#ffffff;letter-spacing:2px;">VEAF</h1>
+              <p style="margin:6px 0 0;font-size:13px;color:#d9eef9;">Virtual European Air Force</p>
+            </td>
+          </tr>
+          <!-- Content -->
+          <tr>
+            <td style="background-color:#ffffff;padding:32px 28px;color:#333333;font-size:15px;line-height:1.6;">
+              {% block content %}{{ body }}{% endblock %}
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="padding:20px 24px;text-align:center;font-size:12px;color:#999999;border-radius:0 0 8px 8px;">
+              <p style="margin:0 0 4px;">&copy; {{ year }} VEAF &mdash; Virtual European Air Force</p>
+              <p style="margin:0;"><a href="{{ app_url }}" style="color:#2fa4e7;text-decoration:none;">{{ app_url }}</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/backend/app/templates/email/register.html
+++ b/backend/app/templates/email/register.html
@@ -1,0 +1,16 @@
+{% extends "default.html" %}
+{% block title %}Bienvenue sur le site de la VEAF{% endblock %}
+{% block content %}
+<h2 style="margin:0 0 16px;font-size:22px;color:#033c73;">Bienvenue sur le site de la VEAF, {{ nickname }} !</h2>
+<p style="margin:0 0 12px;">Votre compte a bien &eacute;t&eacute; cr&eacute;&eacute;.</p>
+<p style="margin:0 0 24px;">Vous pouvez d&egrave;s &agrave; pr&eacute;sent vous connecter sur le site :</p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+  <tr>
+    <td align="center" style="background-color:#2fa4e7;border-radius:6px;">
+      <a href="{{ app_url }}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:bold;text-decoration:none;border-radius:6px;">Acc&eacute;der au site</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0 0 8px;">&Agrave; bient&ocirc;t sur nos serveurs !</p>
+<p style="margin:0;color:#666666;font-style:italic;">L'&eacute;quipe VEAF</p>
+{% endblock %}

--- a/backend/app/templates/email/reset_password.html
+++ b/backend/app/templates/email/reset_password.html
@@ -1,0 +1,18 @@
+{% extends "default.html" %}
+{% block title %}R&eacute;initialisation de votre mot de passe - VEAF{% endblock %}
+{% block content %}
+<h2 style="margin:0 0 16px;font-size:22px;color:#033c73;">R&eacute;initialisation de votre mot de passe</h2>
+<p style="margin:0 0 12px;">Bonjour {{ nickname }},</p>
+<p style="margin:0 0 12px;">Vous avez demand&eacute; la r&eacute;initialisation de votre mot de passe.</p>
+<p style="margin:0 0 24px;">Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe :</p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+  <tr>
+    <td align="center" style="background-color:#2fa4e7;border-radius:6px;">
+      <a href="{{ reset_url }}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:bold;text-decoration:none;border-radius:6px;">R&eacute;initialiser mon mot de passe</a>
+    </td>
+  </tr>
+</table>
+<p style="margin:0 0 8px;font-size:13px;color:#999999;">Ce lien est valable pendant 24 heures.</p>
+<p style="margin:0 0 16px;font-size:13px;color:#999999;">Si vous n'&ecirc;tes pas &agrave; l'origine de cette demande, ignorez cet email.</p>
+<p style="margin:0;color:#666666;font-style:italic;">L'&eacute;quipe VEAF</p>
+{% endblock %}

--- a/backend/tests/unit/services/test_email.py
+++ b/backend/tests/unit/services/test_email.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[3] / "app" / "templates" / "email"
+
+
+def _render(template_name: str, **kwargs) -> str:
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+    template = env.get_template(template_name)
+    return template.render(**kwargs)
+
+
+class TestDefaultTemplate:
+    def test_renders_body_content(self):
+        # GIVEN
+        body = "<p>Contenu de test</p>"
+
+        # WHEN
+        result = _render("default.html", body=body, app_url="https://veaf.org", year=2026)
+
+        # THEN
+        assert "Contenu de test" in result
+        assert "VEAF" in result
+        assert "https://veaf.org" in result
+        assert "2026" in result
+
+    def test_contains_footer(self):
+        # GIVEN / WHEN
+        result = _render("default.html", body="", app_url="https://veaf.org", year=2026)
+
+        # THEN
+        assert "Virtual European Air Force" in result
+
+
+class TestRegisterTemplate:
+    def test_renders_nickname(self):
+        # GIVEN
+        nickname = "TestPilot"
+
+        # WHEN
+        result = _render("register.html", nickname=nickname, app_url="https://veaf.org", year=2026)
+
+        # THEN
+        assert "TestPilot" in result
+        assert "Bienvenue" in result
+
+    def test_contains_cta_link(self):
+        # GIVEN / WHEN
+        result = _render("register.html", nickname="Pilote", app_url="https://veaf.org", year=2026)
+
+        # THEN
+        assert 'href="https://veaf.org"' in result
+
+    def test_extends_default_layout(self):
+        # GIVEN / WHEN
+        result = _render("register.html", nickname="Pilote", app_url="https://veaf.org", year=2026)
+
+        # THEN
+        assert "Virtual European Air Force" in result
+        assert "2026" in result
+
+
+class TestResetPasswordTemplate:
+    def test_renders_nickname_and_reset_url(self):
+        # GIVEN
+        nickname = "TestPilot"
+        reset_url = "https://veaf.org/reset-password?token=abc123"
+
+        # WHEN
+        result = _render("reset_password.html", nickname=nickname, reset_url=reset_url, app_url="https://veaf.org", year=2026)
+
+        # THEN
+        assert "TestPilot" in result
+        assert reset_url in result
+
+    def test_contains_validity_notice(self):
+        # GIVEN / WHEN
+        result = _render(
+            "reset_password.html",
+            nickname="Pilote",
+            reset_url="https://veaf.org/reset",
+            app_url="https://veaf.org",
+            year=2026,
+        )
+
+        # THEN
+        assert "24 heures" in result
+
+    def test_extends_default_layout(self):
+        # GIVEN / WHEN
+        result = _render(
+            "reset_password.html",
+            nickname="Pilote",
+            reset_url="https://veaf.org/reset",
+            app_url="https://veaf.org",
+            year=2026,
+        )
+
+        # THEN
+        assert "Virtual European Air Force" in result


### PR DESCRIPTION
## Summary by Sourcery

Introduce Jinja-based HTML email templates and wire them into the email service and CLI for templated mail sending.

New Features:
- Add reusable HTML email templates for default layout, registration, and password reset emails.
- Expose a generic helper to send emails using named templates with shared context variables such as app URL and year.
- Extend the email CLI command to send test emails using a specified template and prefilled template variables for common templates.

Tests:
- Add unit tests to verify rendering and content of the default, registration, and password reset email templates.