### PR TITLE
fix html and js cache errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.1
 
-- FIXED system - html and js frontend cache cause failures
+- FIXED system - HTML and JS frontend caches causing failures
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- FIXED system - html and js frontend cache cause failures
+
 ## 2.1.0
 
 - ADDED roster - BMS section (available also from Landing page)

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -36,5 +36,10 @@ server {
         proxy_pass http://frontend:80;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
+
+        # Pass cache headers from frontend nginx
+        proxy_pass_header Cache-Control;
+        proxy_pass_header Pragma;
+        proxy_pass_header Expires;
     }
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,6 +22,13 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 
+    # Never cache index.html (SPA entry point — must always fetch latest)
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
     # API requests → backend (needed for OG bot rewrite)
     location ~ ^/api(/.*)?$ {
         proxy_pass http://backend:8000;
@@ -41,7 +48,14 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Cache static assets
+    # Vite hashed assets — no SPA fallback, real 404 if missing
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # Cache other static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -24,9 +24,9 @@ server {
 
     # Never cache index.html (SPA entry point — must always fetch latest)
     location = /index.html {
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires "0";
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
     }
 
     # API requests → backend (needed for OG bot rewrite)


### PR DESCRIPTION
## Summary by Sourcery

Adjust frontend and deployment Nginx caching rules to prevent stale HTML/JS while keeping static asset caching, and document the change in the changelog.

Bug Fixes:
- Disable caching for index.html to ensure the SPA entry point is always fetched fresh and avoid stale HTML/JS issues.

Enhancements:
- Separate Vite hashed assets into a dedicated location block that serves real 404s instead of falling back to the SPA entrypoint.
- Forward cache-related headers from the frontend Nginx to the deploy Nginx proxy to preserve caching behavior across layers.

Documentation:
- Update the changelog with a new 2.1.1 entry describing the frontend cache fix.