### PR TITLE
cleanup old docker images on registry

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -9,7 +9,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     permissions:
-      packages: delete
+      packages: write
     strategy:
       matrix:
         package:

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,25 @@
+name: Cleanup untagged Docker images
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'  # Sunday 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: delete
+    strategy:
+      matrix:
+        package:
+          - website-2026-backend
+          - website-2026-frontend
+    steps:
+      - name: Delete untagged versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: container
+          delete-only-untagged-versions: true
+          min-versions-to-keep: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.1
 
 - FIXED system - HTML and JS frontend caches causing failures
+- FIXED system - cleanup old docker images on registry
 
 ## 2.1.0
 


### PR DESCRIPTION
## Summary by Sourcery

Add scheduled GitHub Actions workflow to regularly clean up untagged Docker images from the container registry and document the change in the changelog.

Bug Fixes:
- Ensure old untagged Docker images are automatically cleaned up from the registry to prevent accumulation of unused images.

CI:
- Introduce a scheduled GitHub Actions workflow that deletes untagged container package versions while keeping a minimum number of recent images.