### PR TITLE
add admin DCS players view and form

### DIFF
--- a/backend/app/api/admin_players.py
+++ b/backend/app/api/admin_players.py
@@ -61,11 +61,12 @@ async def list_players(
     user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    query = select(Player, User).outerjoin(User, User.player_id == Player.id)
-
+    # The linked user is joined in (rather than lazy-loaded) so that the search can
+    # also match on their nickname. Filters are shared between count and page query.
+    filters = []
     if search:
         pattern = f"%{search}%"
-        query = query.where(
+        filters.append(
             or_(
                 Player.nickname.ilike(pattern),
                 Player.ucid.ilike(pattern),
@@ -73,10 +74,17 @@ async def list_players(
             )
         )
 
-    count_query = select(func.count()).select_from(query.subquery())
+    count_query = select(func.count(Player.id)).outerjoin(User, User.player_id == Player.id).where(*filters)
     total = (await db.execute(count_query)).scalar_one()
 
-    query = query.order_by(Player.nickname.asc()).offset(skip).limit(limit)
+    query = (
+        select(Player, User)
+        .outerjoin(User, User.player_id == Player.id)
+        .where(*filters)
+        .order_by(Player.nickname.asc())
+        .offset(skip)
+        .limit(limit)
+    )
     result = await db.execute(query)
 
     return AdminPlayerListOut(

--- a/backend/app/api/admin_players.py
+++ b/backend/app/api/admin_players.py
@@ -1,0 +1,177 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import require_admin
+from app.database import get_db
+from app.models.dcs import Player
+from app.models.user import User
+from app.schemas.dcs import AdminPlayerListOut, PlayerCreate, PlayerOut, PlayerUpdate
+
+router = APIRouter(prefix="/admin/players", tags=["admin-players"])
+
+
+def _build_player_out(player: Player, linked_user: User | None) -> PlayerOut:
+    """Build a PlayerOut DTO from a Player and its (optional) linked user."""
+    return PlayerOut(
+        id=player.id,
+        ucid=player.ucid,
+        nickname=player.nickname,
+        join_at=player.join_at,
+        last_join_at=player.last_join_at,
+        user_id=linked_user.id if linked_user else None,
+        user_nickname=linked_user.nickname if linked_user else None,
+    )
+
+
+async def _linked_user(db: AsyncSession, player: Player) -> User | None:
+    """Return the user currently linked to this player, if any."""
+    result = await db.execute(select(User).where(User.player_id == player.id))
+    return result.scalars().first()
+
+
+async def _apply_user_link(db: AsyncSession, player: Player, user_id: int | None) -> User | None:
+    """Link the player to a user (or unlink it), and return the resulting linked user.
+
+    The relation is owned by User.player_id, so any other user pointing to this player
+    must be detached first.
+    """
+    result = await db.execute(select(User).where(User.player_id == player.id))
+    for previous in result.scalars().all():
+        if previous.id != user_id:
+            previous.player_id = None
+
+    if user_id is None:
+        return None
+
+    target = await db.get(User, user_id)
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilisateur non trouvé")
+
+    target.player_id = player.id
+    return target
+
+
+@router.get("", response_model=AdminPlayerListOut)
+async def list_players(
+    search: str | None = Query(None),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    query = select(Player, User).outerjoin(User, User.player_id == Player.id)
+
+    if search:
+        pattern = f"%{search}%"
+        query = query.where(
+            or_(
+                Player.nickname.ilike(pattern),
+                Player.ucid.ilike(pattern),
+                User.nickname.ilike(pattern),
+            )
+        )
+
+    count_query = select(func.count()).select_from(query.subquery())
+    total = (await db.execute(count_query)).scalar_one()
+
+    query = query.order_by(Player.nickname.asc()).offset(skip).limit(limit)
+    result = await db.execute(query)
+
+    return AdminPlayerListOut(
+        items=[_build_player_out(player, linked_user) for player, linked_user in result.all()],
+        total=total,
+    )
+
+
+@router.post("", response_model=PlayerOut, status_code=status.HTTP_201_CREATED)
+async def create_player(
+    data: PlayerCreate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    player = Player(
+        ucid=data.ucid,
+        nickname=data.nickname,
+    )
+    db.add(player)
+
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Un joueur avec cet UCID existe déjà",
+        )
+
+    linked_user = await _apply_user_link(db, player, data.user_id)
+
+    await db.commit()
+    await db.refresh(player)
+
+    return _build_player_out(player, linked_user)
+
+
+@router.get("/{player_id}", response_model=PlayerOut)
+async def get_player(
+    player_id: int,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    player = await db.get(Player, player_id)
+    if player is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Joueur non trouvé")
+    return _build_player_out(player, await _linked_user(db, player))
+
+
+@router.put("/{player_id}", response_model=PlayerOut)
+async def update_player(
+    player_id: int,
+    data: PlayerUpdate,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    player = await db.get(Player, player_id)
+    if player is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Joueur non trouvé")
+
+    player.ucid = data.ucid
+    player.nickname = data.nickname
+
+    # Flush before touching the user link: _apply_user_link queries User, and the
+    # resulting autoflush would raise the UCID conflict outside of this handler.
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Un joueur avec cet UCID existe déjà",
+        )
+
+    linked_user = await _apply_user_link(db, player, data.user_id)
+
+    await db.commit()
+    await db.refresh(player)
+
+    return _build_player_out(player, linked_user)
+
+
+@router.delete("/{player_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_player(
+    player_id: int,
+    user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    player = await db.get(Player, player_id)
+    if player is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Joueur non trouvé")
+
+    # User owns the FK: detach it before deleting the player
+    await _apply_user_link(db, player, None)
+
+    await db.delete(player)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/admin_stats.py
+++ b/backend/app/api/admin_stats.py
@@ -7,7 +7,7 @@ from app.auth.dependencies import require_admin
 from app.database import get_db
 from app.models.calendar import CalendarEvent
 from app.models.content import File, MenuItem, Page, Url
-from app.models.dcs import Server
+from app.models.dcs import Player, Server
 from app.models.module import Module
 from app.models.recruitment import RecruitmentEvent
 from app.models.user import User
@@ -25,6 +25,7 @@ class AdminStats(BaseModel):
     urls: int = 0
     menu_items: int = 0
     servers: int = 0
+    players: int = 0
     cadets_ready_to_promote: int = 0
     recruitment_events: int = 0
 
@@ -61,6 +62,9 @@ async def get_stats(
     result = await db.execute(select(func.count()).select_from(Server))
     servers_count = result.scalar_one()
 
+    result = await db.execute(select(func.count()).select_from(Player))
+    players_count = result.scalar_one()
+
     result = await db.execute(
         select(func.count())
         .select_from(User)
@@ -86,6 +90,7 @@ async def get_stats(
         urls=urls_count,
         menu_items=menu_items_count,
         servers=servers_count,
+        players=players_count,
         cadets_ready_to_promote=cadets_ready_count,
         recruitment_events=recruitment_events_count,
     )

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api import admin_events, admin_files, admin_menu, admin_modules, admin_pages, admin_recruitment, admin_servers, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, discord_voice, files, header, map, menu, metrics, mission_maker, modules, opengraph, pages, recruitment, roster, servers, teamspeak, urls, users
+from app.api import admin_events, admin_files, admin_menu, admin_modules, admin_pages, admin_players, admin_recruitment, admin_servers, admin_stats, admin_urls, admin_users, auth, calendar, dcsbot, discord_voice, files, header, map, menu, metrics, mission_maker, modules, opengraph, pages, recruitment, roster, servers, teamspeak, urls, users
 
 api_router = APIRouter(prefix="/api")
 
@@ -9,6 +9,7 @@ api_router.include_router(admin_files.router)
 api_router.include_router(admin_menu.router)
 api_router.include_router(admin_modules.router)
 api_router.include_router(admin_pages.router)
+api_router.include_router(admin_players.router)
 api_router.include_router(admin_recruitment.router)
 api_router.include_router(admin_servers.router)
 api_router.include_router(admin_stats.router)

--- a/backend/app/schemas/dcs.py
+++ b/backend/app/schemas/dcs.py
@@ -162,6 +162,24 @@ class PlayerOut(BaseModel):
     nickname: str | None = None
     join_at: datetime | None = None
     last_join_at: datetime | None = None
+    user_id: int | None = None
     user_nickname: str | None = None
 
     model_config = {"from_attributes": True}
+
+
+class PlayerCreate(BaseModel):
+    ucid: str
+    nickname: str | None = None
+    user_id: int | None = None
+
+
+class PlayerUpdate(BaseModel):
+    ucid: str
+    nickname: str | None = None
+    user_id: int | None = None
+
+
+class AdminPlayerListOut(BaseModel):
+    items: list[PlayerOut]
+    total: int

--- a/backend/fixtures/__init__.py
+++ b/backend/fixtures/__init__.py
@@ -7,6 +7,7 @@ async def load_all() -> None:
 
     from fixtures.calendar import load_calendar_events
     from fixtures.content import load_content
+    from fixtures.dcs import load_players
     from fixtures.modules import load_modules
     from fixtures.reference import load_reference_data
     from fixtures.user_modules import load_user_modules
@@ -24,6 +25,7 @@ async def load_all() -> None:
         await load_content(session)
 
         # Level 4: Cross-references
+        await load_players(session, users)
         await load_user_modules(session, users, modules)
         await load_calendar_events(session, users, modules, servers)
 

--- a/backend/fixtures/dcs.py
+++ b/backend/fixtures/dcs.py
@@ -1,0 +1,69 @@
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dcs import Player
+from app.models.user import User
+
+# "user" is the fixture key of the account linked to the player (None = unlinked player)
+PLAYERS_DATA = [
+    {
+        "user": "mitch",
+        "ucid": "3f9a1c7e4b8d05612a7f3e9c1d4b8a06",
+        "nickname": "mitch",
+        "join_at": datetime(2024, 3, 12, 20, 15, tzinfo=UTC),
+        "last_join_at": datetime(2026, 7, 18, 21, 40, tzinfo=UTC),
+    },
+    {
+        "user": "zip",
+        "ucid": "8c2d5f1b9e304a7c6d1f8b2e5a903c74",
+        "nickname": "zip",
+        "join_at": datetime(2023, 11, 2, 19, 5, tzinfo=UTC),
+        "last_join_at": datetime(2026, 7, 22, 20, 10, tzinfo=UTC),
+    },
+    {
+        "user": "sky",
+        "ucid": "d41b7a9c052e6f381cb4d7e2a95f0863",
+        "nickname": "Sky_VEAF",
+        "join_at": datetime(2025, 1, 24, 18, 30, tzinfo=UTC),
+        "last_join_at": datetime(2026, 6, 30, 22, 55, tzinfo=UTC),
+    },
+    {
+        "user": None,
+        "ucid": "6e0f3b8d17c45a92e8d306b1f7a4c25b",
+        "nickname": "Maverick",
+        "join_at": datetime(2026, 2, 8, 21, 0, tzinfo=UTC),
+        "last_join_at": datetime(2026, 7, 20, 19, 25, tzinfo=UTC),
+    },
+    {
+        "user": None,
+        "ucid": "b17d94e2f6035c8a4d2b7f19e806c3a5",
+        "nickname": "Goose",
+        "join_at": datetime(2026, 5, 17, 20, 45, tzinfo=UTC),
+        "last_join_at": datetime(2026, 5, 17, 23, 10, tzinfo=UTC),
+    },
+]
+
+
+async def load_players(session: AsyncSession, users: dict[str, User]) -> dict[str, Player]:
+    players: dict[str, Player] = {}
+    for data in PLAYERS_DATA:
+        player = Player(
+            ucid=data["ucid"],
+            nickname=data["nickname"],
+            join_at=data["join_at"],
+            last_join_at=data["last_join_at"],
+        )
+        session.add(player)
+        players[data["ucid"]] = player
+
+    await session.flush()
+
+    # User owns the FK to Player
+    for data in PLAYERS_DATA:
+        if data["user"] is not None:
+            users[data["user"]].player_id = players[data["ucid"]].id
+
+    await session.flush()
+
+    return players

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -75,6 +75,14 @@ class ServerFactory(factory.Factory):
     code = factory.Sequence(lambda n: f"srv{n}")
 
 
+class PlayerFactory(factory.Factory):
+    class Meta:
+        model = Player
+
+    ucid = factory.Sequence(lambda n: f"ucid{n:028d}")
+    nickname = factory.Sequence(lambda n: f"DcsPilot{n}")
+
+
 class PageFactory(factory.Factory):
     class Meta:
         model = Page

--- a/backend/tests/integration/api/test_admin_players.py
+++ b/backend/tests/integration/api/test_admin_players.py
@@ -1,0 +1,512 @@
+"""Integration tests for admin DCS player CRUD endpoints."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import create_access_token
+from app.models.dcs import Player
+from app.models.user import User
+from tests.factories import AdminFactory, PlayerFactory, UserFactory
+
+
+async def _create_admin(db: AsyncSession) -> tuple:
+    """Create an admin user and return (user, auth_headers)."""
+    user = AdminFactory.build()
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_user(db: AsyncSession, **overrides) -> tuple:
+    """Create a regular user and return (user, auth_headers)."""
+    user = UserFactory.build(**overrides)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    token = create_access_token(user.id, user.get_roles_list())
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+async def _create_player(db: AsyncSession, **overrides) -> Player:
+    """Create and return a DCS player."""
+    player = PlayerFactory.build(**overrides)
+    db.add(player)
+    await db.commit()
+    await db.refresh(player)
+    return player
+
+
+async def _link(db: AsyncSession, user: User, player: Player) -> None:
+    """Link a user to a player (the User side owns the FK)."""
+    user.player_id = player.id
+    await db.commit()
+
+
+# =============================================================================
+# List players — GET /api/admin/players
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_players_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_player(db_session, nickname="Alpha")
+    await _create_player(db_session, nickname="Bravo")
+
+    # WHEN
+    response = await client.get("/api/admin/players", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    assert len(data["items"]) == 2
+    assert data["items"][0]["nickname"] == "Alpha"
+
+
+@pytest.mark.asyncio
+async def test_list_players_exposes_ucid(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_player(db_session, nickname="Maverick", ucid="3f9a1c7e4b8d05612a7f3e9c1d4b8a06")
+
+    # WHEN
+    response = await client.get("/api/admin/players", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    assert response.json()["items"][0]["ucid"] == "3f9a1c7e4b8d05612a7f3e9c1d4b8a06"
+
+
+@pytest.mark.asyncio
+async def test_list_players_includes_linked_user(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    pilot, _ = await _create_user(db_session, nickname="Zip")
+    player = await _create_player(db_session, nickname="Zip_DCS")
+    await _link(db_session, pilot, player)
+    await _create_player(db_session, nickname="Unlinked")
+
+    # WHEN
+    response = await client.get("/api/admin/players", params={"search": "Zip_DCS"}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["user_id"] == pilot.id
+    assert item["user_nickname"] == "Zip"
+
+
+@pytest.mark.asyncio
+async def test_list_players_unlinked_player_has_no_user(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_player(db_session, nickname="Solo")
+
+    # WHEN
+    response = await client.get("/api/admin/players", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["user_id"] is None
+    assert item["user_nickname"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_players_search_by_ucid(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_player(db_session, nickname="Alpha", ucid="aaaa1111bbbb2222cccc3333dddd4444")
+    await _create_player(db_session, nickname="Bravo", ucid="99998888777766665555444433332222")
+
+    # WHEN
+    response = await client.get("/api/admin/players", params={"search": "bbbb2222"}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["nickname"] == "Alpha"
+
+
+@pytest.mark.asyncio
+async def test_list_players_search_by_nickname(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_player(db_session, nickname="Maverick")
+    await _create_player(db_session, nickname="Goose")
+
+    # WHEN
+    response = await client.get("/api/admin/players", params={"search": "maver"}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["nickname"] == "Maverick"
+
+
+@pytest.mark.asyncio
+async def test_list_players_search_by_user_nickname(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    pilot, _ = await _create_user(db_session, nickname="Jarhead")
+    player = await _create_player(db_session, nickname="Alpha")
+    await _link(db_session, pilot, player)
+    await _create_player(db_session, nickname="Bravo")
+
+    # WHEN
+    response = await client.get("/api/admin/players", params={"search": "jarhead"}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["nickname"] == "Alpha"
+
+
+@pytest.mark.asyncio
+async def test_list_players_pagination(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    for i in range(5):
+        await _create_player(db_session, nickname=f"Pilot {i}")
+
+    # WHEN
+    response = await client.get("/api/admin/players", params={"skip": 2, "limit": 2}, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 5
+    assert len(data["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_players_unauthenticated(client: AsyncClient):
+    # GIVEN - no auth headers
+
+    # WHEN
+    response = await client.get("/api/admin/players")
+
+    # THEN
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_players_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.get("/api/admin/players", headers=headers)
+
+    # THEN
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Create player — POST /api/admin/players
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_player_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.post("/api/admin/players", json={
+        "ucid": "3f9a1c7e4b8d05612a7f3e9c1d4b8a06",
+        "nickname": "Maverick",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 201
+    data = response.json()
+    assert data["ucid"] == "3f9a1c7e4b8d05612a7f3e9c1d4b8a06"
+    assert data["nickname"] == "Maverick"
+    assert data["user_id"] is None
+    assert data["id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_player_with_user_link(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    pilot, _ = await _create_user(db_session, nickname="Zip")
+
+    # WHEN
+    response = await client.post("/api/admin/players", json={
+        "ucid": "8c2d5f1b9e304a7c6d1f8b2e5a903c74",
+        "nickname": "Zip_DCS",
+        "user_id": pilot.id,
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 201
+    data = response.json()
+    assert data["user_id"] == pilot.id
+    assert data["user_nickname"] == "Zip"
+    await db_session.refresh(pilot)
+    assert pilot.player_id == data["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_player_duplicate_ucid(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_player(db_session, ucid="3f9a1c7e4b8d05612a7f3e9c1d4b8a06")
+
+    # WHEN
+    response = await client.post("/api/admin/players", json={
+        "ucid": "3f9a1c7e4b8d05612a7f3e9c1d4b8a06",
+        "nickname": "Clone",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_player_unknown_user(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.post("/api/admin/players", json={
+        "ucid": "3f9a1c7e4b8d05612a7f3e9c1d4b8a06",
+        "nickname": "Maverick",
+        "user_id": 99999,
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_player_unauthorized(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_user(db_session)
+
+    # WHEN
+    response = await client.post("/api/admin/players", json={
+        "ucid": "3f9a1c7e4b8d05612a7f3e9c1d4b8a06",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Get player — GET /api/admin/players/{player_id}
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_player_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    pilot, _ = await _create_user(db_session, nickname="Zip")
+    player = await _create_player(db_session, nickname="Zip_DCS")
+    await _link(db_session, pilot, player)
+
+    # WHEN
+    response = await client.get(f"/api/admin/players/{player.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ucid"] == player.ucid
+    assert data["user_nickname"] == "Zip"
+
+
+@pytest.mark.asyncio
+async def test_get_player_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.get("/api/admin/players/99999", headers=headers)
+
+    # THEN
+    assert response.status_code == 404
+
+
+# =============================================================================
+# Update player — PUT /api/admin/players/{player_id}
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_player_ucid(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    player = await _create_player(db_session, ucid="aaaa1111bbbb2222cccc3333dddd4444", nickname="Alpha")
+
+    # WHEN
+    response = await client.put(f"/api/admin/players/{player.id}", json={
+        "ucid": "99998888777766665555444433332222",
+        "nickname": "Alpha",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    assert response.json()["ucid"] == "99998888777766665555444433332222"
+    await db_session.refresh(player)
+    assert player.ucid == "99998888777766665555444433332222"
+
+
+@pytest.mark.asyncio
+async def test_update_player_duplicate_ucid(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    await _create_player(db_session, ucid="aaaa1111bbbb2222cccc3333dddd4444")
+    player = await _create_player(db_session, ucid="99998888777766665555444433332222")
+
+    # WHEN
+    response = await client.put(f"/api/admin/players/{player.id}", json={
+        "ucid": "aaaa1111bbbb2222cccc3333dddd4444",
+        "nickname": "Clone",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_update_player_links_user(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    pilot, _ = await _create_user(db_session, nickname="Zip")
+    player = await _create_player(db_session, nickname="Zip_DCS")
+
+    # WHEN
+    response = await client.put(f"/api/admin/players/{player.id}", json={
+        "ucid": player.ucid,
+        "nickname": "Zip_DCS",
+        "user_id": pilot.id,
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    assert response.json()["user_nickname"] == "Zip"
+    await db_session.refresh(pilot)
+    assert pilot.player_id == player.id
+
+
+@pytest.mark.asyncio
+async def test_update_player_unlinks_user(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    pilot, _ = await _create_user(db_session, nickname="Zip")
+    player = await _create_player(db_session, nickname="Zip_DCS")
+    await _link(db_session, pilot, player)
+
+    # WHEN
+    response = await client.put(f"/api/admin/players/{player.id}", json={
+        "ucid": player.ucid,
+        "nickname": "Zip_DCS",
+        "user_id": None,
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user_id"] is None
+    assert data["user_nickname"] is None
+    await db_session.refresh(pilot)
+    assert pilot.player_id is None
+
+
+@pytest.mark.asyncio
+async def test_update_player_moving_link_detaches_previous_user(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    previous, _ = await _create_user(db_session, nickname="Previous")
+    new_owner, _ = await _create_user(db_session, nickname="NewOwner")
+    player = await _create_player(db_session, nickname="Shared")
+    await _link(db_session, previous, player)
+
+    # WHEN
+    response = await client.put(f"/api/admin/players/{player.id}", json={
+        "ucid": player.ucid,
+        "nickname": "Shared",
+        "user_id": new_owner.id,
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 200
+    assert response.json()["user_nickname"] == "NewOwner"
+    await db_session.refresh(previous)
+    await db_session.refresh(new_owner)
+    assert previous.player_id is None
+    assert new_owner.player_id == player.id
+
+
+@pytest.mark.asyncio
+async def test_update_player_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.put("/api/admin/players/99999", json={
+        "ucid": "3f9a1c7e4b8d05612a7f3e9c1d4b8a06",
+    }, headers=headers)
+
+    # THEN
+    assert response.status_code == 404
+
+
+# =============================================================================
+# Delete player — DELETE /api/admin/players/{player_id}
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_player_success(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    player = await _create_player(db_session, nickname="Ghost")
+
+    # WHEN
+    response = await client.delete(f"/api/admin/players/{player.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    assert await db_session.get(Player, player.id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_player_detaches_linked_user(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+    pilot, _ = await _create_user(db_session, nickname="Zip")
+    player = await _create_player(db_session, nickname="Zip_DCS")
+    await _link(db_session, pilot, player)
+
+    # WHEN
+    response = await client.delete(f"/api/admin/players/{player.id}", headers=headers)
+
+    # THEN
+    assert response.status_code == 204
+    await db_session.refresh(pilot)
+    assert pilot.player_id is None
+    assert await db_session.get(User, pilot.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_player_not_found(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN
+    _, headers = await _create_admin(db_session)
+
+    # WHEN
+    response = await client.delete("/api/admin/players/99999", headers=headers)
+
+    # THEN
+    assert response.status_code == 404

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -10,6 +10,7 @@ export interface AdminStats {
   urls: number
   menu_items: number
   servers: number
+  players: number
   cadets_ready_to_promote: number
   recruitment_events: number
 }

--- a/frontend/src/api/players.ts
+++ b/frontend/src/api/players.ts
@@ -1,0 +1,27 @@
+import apiClient from './client'
+import type { Player, PlayerCreate, PlayerUpdate, AdminPlayerListResponse } from '@/types/api'
+
+// --- Admin ---
+
+export async function getAdminPlayers(params?: {
+  search?: string
+  skip?: number
+  limit?: number
+}): Promise<AdminPlayerListResponse> {
+  const { data } = await apiClient.get<AdminPlayerListResponse>('/admin/players', { params })
+  return data
+}
+
+export async function createAdminPlayer(payload: PlayerCreate): Promise<Player> {
+  const { data } = await apiClient.post<Player>('/admin/players', payload)
+  return data
+}
+
+export async function updateAdminPlayer(playerId: number, payload: PlayerUpdate): Promise<Player> {
+  const { data } = await apiClient.put<Player>(`/admin/players/${playerId}`, payload)
+  return data
+}
+
+export async function deleteAdminPlayer(playerId: number): Promise<void> {
+  await apiClient.delete(`/admin/players/${playerId}`)
+}

--- a/frontend/src/composables/useDebounce.ts
+++ b/frontend/src/composables/useDebounce.ts
@@ -1,0 +1,39 @@
+import { onBeforeUnmount } from 'vue'
+
+export interface DebouncedFn<T extends unknown[]> {
+  (...args: T): void
+  cancel: () => void
+}
+
+/**
+ * Wrap a function so rapid successive calls collapse into a single deferred call.
+ *
+ * The pending call is cancelled automatically when the component unmounts, and can
+ * be cancelled manually through `cancel()` (e.g. when the input becomes too short
+ * to be worth searching). Must be called during component setup.
+ */
+export function useDebounce<T extends unknown[]>(
+  fn: (...args: T) => void,
+  delay = 300,
+): DebouncedFn<T> {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+
+  function cancel() {
+    if (timeout) {
+      clearTimeout(timeout)
+      timeout = null
+    }
+  }
+
+  const debounced = (...args: T) => {
+    cancel()
+    timeout = setTimeout(() => {
+      timeout = null
+      fn(...args)
+    }, delay)
+  }
+
+  onBeforeUnmount(cancel)
+
+  return Object.assign(debounced, { cancel })
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -271,6 +271,19 @@ const router = createRouter({
       },
     },
     {
+      path: '/admin/players',
+      name: 'admin-players',
+      component: () => import('@/views/admin/PlayersView.vue'),
+      meta: {
+        requiresAuth: true,
+        requiresAdmin: true,
+        breadcrumb: [
+          { label: 'Administration', to: 'admin', icon: 'fa-solid fa-screwdriver-wrench' },
+          { label: 'Joueurs DCS' },
+        ],
+      },
+    },
+    {
       path: '/admin/urls',
       name: 'admin-urls',
       component: () => import('@/views/admin/UrlsView.vue'),

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -174,6 +174,36 @@ export interface AdminServerListResponse {
   total: number
 }
 
+// DCS players (database entity — not to be confused with PlayerEntry, the live
+// player list coming from DCSServerBot)
+
+export interface Player {
+  id: number
+  ucid: string
+  nickname: string | null
+  join_at: string | null
+  last_join_at: string | null
+  user_id: number | null
+  user_nickname: string | null
+}
+
+export interface PlayerCreate {
+  ucid: string
+  nickname: string | null
+  user_id: number | null
+}
+
+export interface PlayerUpdate {
+  ucid: string
+  nickname: string | null
+  user_id: number | null
+}
+
+export interface AdminPlayerListResponse {
+  items: Player[]
+  total: number
+}
+
 // DCSServerBot types
 
 export interface SunState {

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -72,6 +72,11 @@ onMounted(async () => {
         <div class="text-3xl font-bold text-veaf-500 mb-2">{{ stats?.servers ?? '-' }}</div>
         <div class="text-sm text-gray-900">Serveurs</div>
       </RouterLink>
+      <RouterLink to="/admin/players" class="card text-center hover:shadow-md transition-shadow">
+        <div class="text-veaf-400 mb-2"><i class="fa-solid fa-id-card text-2xl"></i></div>
+        <div class="text-3xl font-bold text-veaf-500 mb-2">{{ stats?.players ?? '-' }}</div>
+        <div class="text-sm text-gray-900">Joueurs DCS</div>
+      </RouterLink>
       <RouterLink to="/admin/urls" class="card text-center hover:shadow-md transition-shadow">
         <div class="text-veaf-400 mb-2"><i class="fa-solid fa-link text-2xl"></i></div>
         <div class="text-3xl font-bold text-veaf-500 mb-2">{{ stats?.urls ?? '-' }}</div>

--- a/frontend/src/views/admin/PlayersView.vue
+++ b/frontend/src/views/admin/PlayersView.vue
@@ -1,0 +1,361 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import { getAdminPlayers, createAdminPlayer, updateAdminPlayer, deleteAdminPlayer } from '@/api/players'
+import { getAdminUsers } from '@/api/users'
+import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
+import type { Player } from '@/types/api'
+import { useConfirm } from '@/composables/useConfirm'
+import { useToast } from '@/composables/useToast'
+
+const { confirm } = useConfirm()
+const toast = useToast()
+
+// Data
+const players = ref<Player[]>([])
+const total = ref(0)
+const loading = ref(false)
+
+// Search
+const searchInput = ref('')
+const search = ref('')
+let searchTimeout: ReturnType<typeof setTimeout> | null = null
+
+// Pagination
+const currentPage = ref(1)
+const pageSize = 50
+const totalPages = ref(1)
+
+// Form
+const showForm = ref(false)
+const editingPlayerId = ref<number | null>(null)
+const playerForm = ref({
+  ucid: '',
+  nickname: '',
+})
+
+// User link (autocomplete)
+const linkedUserId = ref<number | null>(null)
+const linkedUserNickname = ref<string | null>(null)
+const userSearch = ref('')
+const userResults = ref<{ id: number; nickname: string }[]>([])
+const userDropdownOpen = ref(false)
+const userSearching = ref(false)
+const userPickerRef = ref<HTMLElement | null>(null)
+let userSearchTimeout: ReturnType<typeof setTimeout> | null = null
+
+function onSearchInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  searchInput.value = value
+  if (searchTimeout) clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    search.value = value
+  }, 300)
+}
+
+async function loadPlayers() {
+  loading.value = true
+  try {
+    const params: Record<string, unknown> = {
+      skip: (currentPage.value - 1) * pageSize,
+      limit: pageSize,
+    }
+    if (search.value) params.search = search.value
+
+    const result = await getAdminPlayers(params as Parameters<typeof getAdminPlayers>[0])
+    players.value = result.items
+    total.value = result.total
+    totalPages.value = Math.max(1, Math.ceil(result.total / pageSize))
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(search, () => {
+  currentPage.value = 1
+  loadPlayers()
+})
+
+function goToPage(page: number) {
+  currentPage.value = page
+  loadPlayers()
+}
+
+// --- User autocomplete ---
+
+function onUserSearchInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  userSearch.value = value
+  if (userSearchTimeout) clearTimeout(userSearchTimeout)
+  if (value.trim().length < 2) {
+    userResults.value = []
+    userDropdownOpen.value = false
+    return
+  }
+  userSearchTimeout = setTimeout(searchUsers, 300)
+}
+
+async function searchUsers() {
+  userSearching.value = true
+  try {
+    const result = await getAdminUsers({ search: userSearch.value.trim(), limit: 10 })
+    userResults.value = result.items.map((u) => ({ id: u.id, nickname: u.nickname }))
+    userDropdownOpen.value = true
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    userSearching.value = false
+  }
+}
+
+function selectUser(user: { id: number; nickname: string }) {
+  linkedUserId.value = user.id
+  linkedUserNickname.value = user.nickname
+  userSearch.value = ''
+  userResults.value = []
+  userDropdownOpen.value = false
+}
+
+function unlinkUser() {
+  linkedUserId.value = null
+  linkedUserNickname.value = null
+}
+
+function onUserPickerClickOutside(event: MouseEvent) {
+  if (userPickerRef.value && !userPickerRef.value.contains(event.target as Node)) {
+    userDropdownOpen.value = false
+  }
+}
+
+// --- Form ---
+
+function openNew() {
+  editingPlayerId.value = null
+  playerForm.value = { ucid: '', nickname: '' }
+  unlinkUser()
+  userSearch.value = ''
+  userResults.value = []
+  showForm.value = true
+}
+
+function openEdit(p: Player) {
+  editingPlayerId.value = p.id
+  playerForm.value = {
+    ucid: p.ucid,
+    nickname: p.nickname ?? '',
+  }
+  linkedUserId.value = p.user_id
+  linkedUserNickname.value = p.user_nickname
+  userSearch.value = ''
+  userResults.value = []
+  showForm.value = true
+}
+
+async function handleSubmit() {
+  loading.value = true
+  try {
+    const payload = {
+      ucid: playerForm.value.ucid.trim(),
+      nickname: playerForm.value.nickname.trim() || null,
+      user_id: linkedUserId.value,
+    }
+    if (editingPlayerId.value) {
+      await updateAdminPlayer(editingPlayerId.value, payload)
+      toast.success('Joueur modifié avec succès')
+    } else {
+      await createAdminPlayer(payload)
+      toast.success('Joueur créé avec succès')
+    }
+    showForm.value = false
+    await loadPlayers()
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleDelete(p: Player) {
+  if (!(await confirm(`Supprimer le joueur DCS "${p.nickname ?? p.ucid}" ?`))) return
+  loading.value = true
+  try {
+    await deleteAdminPlayer(p.id)
+    toast.success('Joueur supprimé avec succès')
+    await loadPlayers()
+  } catch (e) {
+    toast.error(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('fr-FR')
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', onUserPickerClickOutside)
+  loadPlayers()
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', onUserPickerClickOutside)
+})
+</script>
+
+<template>
+  <div>
+    <AppBreadcrumb :show-title="false" />
+
+    <!-- Search & Actions -->
+    <div class="flex flex-wrap gap-4 mb-4">
+      <div class="relative flex-1 min-w-[200px]">
+        <i class="fa-solid fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+        <input
+          :value="searchInput"
+          @input="onSearchInput"
+          type="text"
+          placeholder="Rechercher par pseudo, UCID ou utilisateur..."
+          class="input pl-9 w-full"
+        />
+      </div>
+      <button class="btn-primary" @click="openNew">
+        <i class="fa-solid fa-plus mr-1"></i>Ajouter un joueur
+      </button>
+    </div>
+
+    <!-- Player form -->
+    <div v-if="showForm" class="card mb-6">
+      <h3 class="text-lg font-semibold mb-4">
+        {{ editingPlayerId ? 'Modifier le joueur DCS' : 'Ajouter un joueur DCS' }}
+      </h3>
+      <form class="space-y-4" @submit.prevent="handleSubmit">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="label">UCID</label>
+            <input v-model="playerForm.ucid" type="text" class="input font-mono" maxlength="64" required />
+            <p class="text-xs text-gray-500 mt-1">Identifiant unique du joueur DCS</p>
+          </div>
+          <div>
+            <label class="label">Pseudo</label>
+            <input v-model="playerForm.nickname" type="text" class="input" maxlength="128" />
+            <p class="text-xs text-gray-500 mt-1">Dernier pseudo utilisé en jeu</p>
+          </div>
+        </div>
+
+        <!-- User link -->
+        <div ref="userPickerRef" class="relative">
+          <label class="label">Utilisateur associé</label>
+          <div v-if="linkedUserNickname" class="flex items-center gap-2">
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-veaf-100 text-veaf-800">
+              {{ linkedUserNickname }}
+              <button type="button" class="opacity-60 hover:opacity-100" aria-label="Dissocier l'utilisateur" @click="unlinkUser">
+                <i class="fa-solid fa-xmark text-xs"></i>
+              </button>
+            </span>
+          </div>
+          <template v-else>
+            <input
+              :value="userSearch"
+              @input="onUserSearchInput"
+              type="text"
+              placeholder="Rechercher un utilisateur (2 caractères minimum)..."
+              class="input w-full"
+              autocomplete="off"
+            />
+            <div
+              v-if="userDropdownOpen"
+              class="absolute z-50 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto"
+            >
+              <div
+                v-for="u in userResults"
+                :key="u.id"
+                class="px-3 py-1.5 text-sm text-gray-900 cursor-pointer hover:bg-gray-100"
+                @click="selectUser(u)"
+              >
+                {{ u.nickname }}
+              </div>
+              <div v-if="!userResults.length" class="px-3 py-3 text-sm text-gray-500 text-center">
+                {{ userSearching ? 'Recherche...' : 'Aucun résultat' }}
+              </div>
+            </div>
+          </template>
+          <p class="text-xs text-gray-500 mt-1">Compte VEAF lié à ce joueur DCS (facultatif)</p>
+        </div>
+
+        <div class="flex justify-end space-x-3">
+          <button type="button" class="btn-secondary" @click="showForm = false">
+            <i class="fa-solid fa-xmark mr-1"></i>Annuler
+          </button>
+          <button type="submit" class="btn-primary" :disabled="loading">
+            <i class="fa-solid fa-floppy-disk mr-1"></i>{{ loading ? 'Enregistrement...' : editingPlayerId ? 'Modifier' : 'Créer' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Players table -->
+    <div class="card overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b text-left">
+            <th class="p-2">Pseudo</th>
+            <th class="p-2">UCID</th>
+            <th class="p-2">Utilisateur</th>
+            <th class="p-2">Première connexion</th>
+            <th class="p-2">Dernière connexion</th>
+            <th class="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="!players.length">
+            <td colspan="6" class="p-4 text-center text-gray-500">Aucun joueur DCS</td>
+          </tr>
+          <tr v-for="p in players" :key="p.id" class="border-b hover:bg-gray-50">
+            <td class="p-2 font-medium">{{ p.nickname ?? '-' }}</td>
+            <td class="p-2 font-mono text-xs">{{ p.ucid }}</td>
+            <td class="p-2">
+              <span v-if="p.user_nickname">{{ p.user_nickname }}</span>
+              <span v-else class="text-gray-500 italic">non associé</span>
+            </td>
+            <td class="p-2">{{ formatDate(p.join_at) }}</td>
+            <td class="p-2">{{ formatDate(p.last_join_at) }}</td>
+            <td class="p-2 space-x-3">
+              <button class="text-veaf-600 hover:text-veaf-800 text-sm" title="Modifier" @click="openEdit(p)">
+                <i class="fa-solid fa-edit"></i>
+              </button>
+              <button class="text-red-600 hover:text-red-800 text-sm" title="Supprimer" @click="handleDelete(p)">
+                <i class="fa-solid fa-trash"></i>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- Pagination -->
+      <div v-if="totalPages > 1" class="flex items-center justify-between p-3 border-t">
+        <span class="text-sm text-gray-600">{{ total }} joueur(s) au total</span>
+        <div class="flex items-center space-x-2">
+          <button
+            class="btn-secondary text-sm"
+            :disabled="currentPage <= 1"
+            @click="goToPage(currentPage - 1)"
+          >
+            <i class="fa-solid fa-chevron-left mr-1"></i>Précédent
+          </button>
+          <span class="text-sm text-gray-600">Page {{ currentPage }} sur {{ totalPages }}</span>
+          <button
+            class="btn-secondary text-sm"
+            :disabled="currentPage >= totalPages"
+            @click="goToPage(currentPage + 1)"
+          >
+            Suivant<i class="fa-solid fa-chevron-right ml-1"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/admin/PlayersView.vue
+++ b/frontend/src/views/admin/PlayersView.vue
@@ -5,6 +5,7 @@ import { getAdminUsers } from '@/api/users'
 import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
 import type { Player } from '@/types/api'
 import { useConfirm } from '@/composables/useConfirm'
+import { useDebounce } from '@/composables/useDebounce'
 import { useToast } from '@/composables/useToast'
 
 const { confirm } = useConfirm()
@@ -18,7 +19,9 @@ const loading = ref(false)
 // Search
 const searchInput = ref('')
 const search = ref('')
-let searchTimeout: ReturnType<typeof setTimeout> | null = null
+const applySearch = useDebounce((value: string) => {
+  search.value = value
+})
 
 // Pagination
 const currentPage = ref(1)
@@ -41,15 +44,11 @@ const userResults = ref<{ id: number; nickname: string }[]>([])
 const userDropdownOpen = ref(false)
 const userSearching = ref(false)
 const userPickerRef = ref<HTMLElement | null>(null)
-let userSearchTimeout: ReturnType<typeof setTimeout> | null = null
 
 function onSearchInput(event: Event) {
   const value = (event.target as HTMLInputElement).value
   searchInput.value = value
-  if (searchTimeout) clearTimeout(searchTimeout)
-  searchTimeout = setTimeout(() => {
-    search.value = value
-  }, 300)
+  applySearch(value)
 }
 
 async function loadPlayers() {
@@ -84,16 +83,20 @@ function goToPage(page: number) {
 
 // --- User autocomplete ---
 
+const debouncedSearchUsers = useDebounce(() => {
+  searchUsers()
+})
+
 function onUserSearchInput(event: Event) {
   const value = (event.target as HTMLInputElement).value
   userSearch.value = value
-  if (userSearchTimeout) clearTimeout(userSearchTimeout)
   if (value.trim().length < 2) {
+    debouncedSearchUsers.cancel()
     userResults.value = []
     userDropdownOpen.value = false
     return
   }
-  userSearchTimeout = setTimeout(searchUsers, 300)
+  debouncedSearchUsers()
 }
 
 async function searchUsers() {
@@ -109,12 +112,18 @@ async function searchUsers() {
   }
 }
 
-function selectUser(user: { id: number; nickname: string }) {
-  linkedUserId.value = user.id
-  linkedUserNickname.value = user.nickname
+/** Clear the picker input and drop any search still pending. */
+function resetUserSearch() {
+  debouncedSearchUsers.cancel()
   userSearch.value = ''
   userResults.value = []
   userDropdownOpen.value = false
+}
+
+function selectUser(user: { id: number; nickname: string }) {
+  linkedUserId.value = user.id
+  linkedUserNickname.value = user.nickname
+  resetUserSearch()
 }
 
 function unlinkUser() {
@@ -134,8 +143,7 @@ function openNew() {
   editingPlayerId.value = null
   playerForm.value = { ucid: '', nickname: '' }
   unlinkUser()
-  userSearch.value = ''
-  userResults.value = []
+  resetUserSearch()
   showForm.value = true
 }
 
@@ -147,8 +155,7 @@ function openEdit(p: Player) {
   }
   linkedUserId.value = p.user_id
   linkedUserNickname.value = p.user_nickname
-  userSearch.value = ''
-  userResults.value = []
+  resetUserSearch()
   showForm.value = true
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce admin management of DCS player records, including CRUD API endpoints, fixtures, and a new admin UI view with search, pagination, and user association, surfaced in the admin dashboard and stats.

New Features:
- Add admin DCS player list, create, update, and delete endpoints with support for linking players to VEAF user accounts and searching by UCID, nickname, or user nickname.
- Add an admin DCS players view in the frontend with search, pagination, player editing/creation form, and user autocomplete linking.
- Expose DCS player statistics in the admin dashboard and stats API.

Enhancements:
- Extend DCS player schema and shared API types to include user linkage fields and an admin list response.
- Load initial DCS player fixtures and link them to existing user fixtures.
- Register the new admin players router and navigation route in the backend API router and frontend router.

Tests:
- Add comprehensive integration tests covering admin DCS player CRUD operations, search, pagination, user linking/unlinking behavior, and authorization rules.