### PR TITLE
fix time remaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## next release
+
+- CHANGED calendar - event badge now refreshes on its own (30s tick), closing votes on time
+- FIXED calendar - time remaining before event start rounded up to whole days ("dans 1j" for an event 1 hour away), now shown as days, hours or minutes
+
+
 ## 2.1.1
 
 - FIXED system - HTML and JS frontend caches causing failures

--- a/frontend/src/composables/useNow.ts
+++ b/frontend/src/composables/useNow.ts
@@ -1,0 +1,18 @@
+import { onUnmounted, ref, type Ref } from 'vue'
+
+const TICK_INTERVAL = 30_000 // 30 seconds
+
+/**
+ * Reactive clock returning the current timestamp, refreshed every `intervalMs`.
+ * The interval is cleared when the calling component is unmounted.
+ */
+export function useNow(intervalMs: number = TICK_INTERVAL): Ref<number> {
+  const now = ref(Date.now())
+  const timer = setInterval(() => {
+    now.value = Date.now()
+  }, intervalMs)
+
+  onUnmounted(() => clearInterval(timer))
+
+  return now
+}

--- a/frontend/src/utils/date.spec.ts
+++ b/frontend/src/utils/date.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { eventTimeBadge, formatTimeUntil } from './date'
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+describe('formatTimeUntil', () => {
+  it('reports an event starting in a bit over an hour in hours and minutes', () => {
+    // GIVEN the case reported in issue #184: 19:59, event starting the same day at 21:00
+    // WHEN / THEN the delay must not be rounded up to a full day
+    expect(formatTimeUntil(HOUR + MINUTE)).toBe('dans 1h01')
+  })
+
+  it('reports a delay under a minute as imminent', () => {
+    expect(formatTimeUntil(30_000)).toBe('imminent')
+    expect(formatTimeUntil(0)).toBe('imminent')
+  })
+
+  it('reports a delay under an hour in minutes', () => {
+    expect(formatTimeUntil(45 * MINUTE)).toBe('dans 45min')
+    expect(formatTimeUntil(MINUTE)).toBe('dans 1min')
+    expect(formatTimeUntil(HOUR - 1)).toBe('dans 59min')
+  })
+
+  it('omits the minutes on a whole number of hours', () => {
+    expect(formatTimeUntil(2 * HOUR)).toBe('dans 2h')
+  })
+
+  it('keeps hours and minutes up to the last minute before a day', () => {
+    expect(formatTimeUntil(23 * HOUR + 59 * MINUTE)).toBe('dans 23h59')
+  })
+
+  it('reports a delay over a day in days and hours', () => {
+    expect(formatTimeUntil(DAY + HOUR)).toBe('dans 1j 1h')
+    expect(formatTimeUntil(3 * DAY + 4 * HOUR)).toBe('dans 3j 4h')
+  })
+
+  it('omits the hours on a whole number of days', () => {
+    expect(formatTimeUntil(DAY)).toBe('dans 1j')
+    expect(formatTimeUntil(3 * DAY)).toBe('dans 3j')
+  })
+
+  it('truncates instead of rounding up', () => {
+    // GIVEN 25h59: floor to 1 day + 1 hour, never 2 days
+    expect(formatTimeUntil(DAY + HOUR + 59 * MINUTE)).toBe('dans 1j 1h')
+  })
+})
+
+describe('eventTimeBadge', () => {
+  const start = '2026-04-15T21:00:00+00:00'
+  const end = '2026-04-15T23:00:00+00:00'
+
+  it('shows the remaining delay for an upcoming event', () => {
+    // GIVEN now is 19:59 on the day of the event
+    const now = new Date('2026-04-15T19:59:00+00:00').getTime()
+
+    // WHEN
+    const badge = eventTimeBadge(start, end, now)
+
+    // THEN
+    expect(badge).toEqual({ text: 'dans 1h01', cssClass: 'bg-green-100 text-green-800' })
+  })
+
+  it('marks a running event', () => {
+    const now = new Date('2026-04-15T22:00:00+00:00').getTime()
+    expect(eventTimeBadge(start, end, now)).toEqual({
+      text: 'en cours !',
+      cssClass: 'bg-yellow-100 text-yellow-800',
+    })
+  })
+
+  it('marks a finished event', () => {
+    const now = new Date('2026-04-16T00:00:00+00:00').getTime()
+    expect(eventTimeBadge(start, end, now)).toEqual({
+      text: 'terminé',
+      cssClass: 'bg-red-100 text-red-800',
+    })
+  })
+
+  it('treats the exact start instant as running and the exact end instant as finished', () => {
+    expect(eventTimeBadge(start, end, new Date(start).getTime()).text).toBe('en cours !')
+    expect(eventTimeBadge(start, end, new Date(end).getTime()).text).toBe('terminé')
+  })
+})

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,47 @@
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+export interface EventTimeBadge {
+  text: string
+  cssClass: string
+}
+
+/**
+ * Format the delay before an event start, with two units at most and no rounding up:
+ * "dans 3j 4h", "dans 2j", "dans 1h01", "dans 2h", "dans 45min", "imminent".
+ */
+export function formatTimeUntil(deltaMs: number): string {
+  if (deltaMs < MINUTE) return 'imminent'
+
+  if (deltaMs < HOUR) {
+    return `dans ${Math.floor(deltaMs / MINUTE)}min`
+  }
+
+  if (deltaMs < DAY) {
+    const hours = Math.floor(deltaMs / HOUR)
+    const minutes = Math.floor((deltaMs % HOUR) / MINUTE)
+    return minutes > 0 ? `dans ${hours}h${String(minutes).padStart(2, '0')}` : `dans ${hours}h`
+  }
+
+  const days = Math.floor(deltaMs / DAY)
+  const hours = Math.floor((deltaMs % DAY) / HOUR)
+  return hours > 0 ? `dans ${days}j ${hours}h` : `dans ${days}j`
+}
+
+/**
+ * Build the state badge of an event: upcoming (with the remaining delay), running, or over.
+ * `now` is injectable so the caller can pass a reactive clock (see `useNow`).
+ */
+export function eventTimeBadge(startDate: string, endDate: string, now: number = Date.now()): EventTimeBadge {
+  const start = new Date(startDate).getTime()
+  const end = new Date(endDate).getTime()
+
+  if (now < start) {
+    return { text: formatTimeUntil(start - now), cssClass: 'bg-green-100 text-green-800' }
+  }
+  if (now < end) {
+    return { text: 'en cours !', cssClass: 'bg-yellow-100 text-yellow-800' }
+  }
+  return { text: 'terminé', cssClass: 'bg-red-100 text-red-800' }
+}

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -12,7 +12,7 @@ import type { DateClickArg } from '@fullcalendar/interaction'
 import { useCalendarStore } from '@/stores/calendar'
 import { useAuthStore } from '@/stores/auth'
 import { useNow } from '@/composables/useNow'
-import { eventTimeBadge } from '@/utils/date'
+import { eventTimeBadge, type EventTimeBadge } from '@/utils/date'
 import type { EventListItem } from '@/types/calendar'
 import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
 
@@ -106,7 +106,7 @@ function formatDate(d: string) {
 
 const eventBadges = computed(
   () =>
-    new Map(
+    new Map<number, EventTimeBadge>(
       calendar.myEvents.map((e: EventListItem) => [e.id, eventTimeBadge(e.start_date, e.end_date, now.value)])
     )
 )

--- a/frontend/src/views/CalendarView.vue
+++ b/frontend/src/views/CalendarView.vue
@@ -11,12 +11,15 @@ import type { EventClickArg, DatesSetArg } from '@fullcalendar/core'
 import type { DateClickArg } from '@fullcalendar/interaction'
 import { useCalendarStore } from '@/stores/calendar'
 import { useAuthStore } from '@/stores/auth'
+import { useNow } from '@/composables/useNow'
+import { eventTimeBadge } from '@/utils/date'
 import type { EventListItem } from '@/types/calendar'
 import AppBreadcrumb from '@/components/ui/AppBreadcrumb.vue'
 
 const router = useRouter()
 const calendar = useCalendarStore()
 const auth = useAuthStore()
+const now = useNow()
 
 const eventTypes = [
   { label: 'Training', color: '#27AE60' },
@@ -101,20 +104,12 @@ function formatDate(d: string) {
   })
 }
 
-function eventTimeBadge(event: EventListItem): { text: string; cssClass: string } {
-  const now = Date.now()
-  const start = new Date(event.start_date).getTime()
-  const end = new Date(event.end_date).getTime()
-
-  if (now < start) {
-    const days = Math.ceil((start - now) / (1000 * 60 * 60 * 24))
-    return { text: `dans ${days}j`, cssClass: 'bg-green-100 text-green-800' }
-  } else if (now < end) {
-    return { text: 'en cours !', cssClass: 'bg-yellow-100 text-yellow-800' }
-  } else {
-    return { text: 'terminé', cssClass: 'bg-red-100 text-red-800' }
-  }
-}
+const eventBadges = computed(
+  () =>
+    new Map(
+      calendar.myEvents.map((e: EventListItem) => [e.id, eventTimeBadge(e.start_date, e.end_date, now.value)])
+    )
+)
 
 onMounted(() => {
   if (auth.isAuthenticated) {
@@ -162,9 +157,9 @@ onMounted(() => {
             <span class="text-gray-600">{{ formatDate(event.start_date) }}</span>
             <span
               class="text-xs font-medium px-2 py-0.5 rounded-full"
-              :class="eventTimeBadge(event).cssClass"
+              :class="eventBadges.get(event.id)?.cssClass"
             >
-              {{ eventTimeBadge(event).text }}
+              {{ eventBadges.get(event.id)?.text }}
             </span>
             <RouterLink
               :to="`/calendar/${event.id}`"

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -7,6 +7,8 @@ import { getEvent, voteEvent, deleteEvent, copyEvent, addChoice, updateChoice, d
 import type { EventDetail, Choice } from '@/types/calendar'
 import { useConfirm } from '@/composables/useConfirm'
 import { renderMarkdown } from '@/composables/useMarkdown'
+import { useNow } from '@/composables/useNow'
+import { eventTimeBadge } from '@/utils/date'
 import ChoiceModal from '@/components/ui/ChoiceModal.vue'
 import { moduleTypeIcon } from '@/constants/modules'
 
@@ -14,6 +16,7 @@ const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
 const calendar = useCalendarStore()
+const now = useNow()
 const event = ref<EventDetail | null>(null)
 const loading = ref(true)
 const activeTab = ref<'description' | 'debrief'>('description')
@@ -48,23 +51,12 @@ const userVote = computed(() => {
 
 const eventStatus = computed(() => {
   if (!event.value) return null
-  const now = Date.now()
-  const start = new Date(event.value.start_date).getTime()
-  const end = new Date(event.value.end_date).getTime()
-
-  if (now < start) {
-    const days = Math.ceil((start - now) / (1000 * 60 * 60 * 24))
-    return { text: `dans ${days}j`, class: 'bg-green-100 text-green-800' }
-  } else if (now < end) {
-    return { text: 'en cours !', class: 'bg-yellow-100 text-yellow-800' }
-  } else {
-    return { text: 'terminé', class: 'bg-red-100 text-red-800' }
-  }
+  return eventTimeBadge(event.value.start_date, event.value.end_date, now.value)
 })
 
 const isFinished = computed(() => {
   if (!event.value) return false
-  return new Date(event.value.end_date).getTime() < Date.now()
+  return new Date(event.value.end_date).getTime() < now.value
 })
 
 const canVote = computed(() => {
@@ -207,7 +199,7 @@ function formatShortDate(d: string) {
             <span
               v-if="eventStatus"
               class="text-xs font-medium px-2 py-0.5 rounded-full ml-2"
-              :class="eventStatus.class"
+              :class="eventStatus.cssClass"
             >
               {{ eventStatus.text }}
             </span>


### PR DESCRIPTION
## Summary by Sourcery

Improve calendar event time badges by using a shared, reactive time source and centralized formatting utilities.

New Features:
- Add a reusable useNow composable that provides a reactive clock updated on a fixed interval.
- Introduce shared date utilities for formatting time until an event and computing event status badges.

Bug Fixes:
- Correct event "time remaining" display to show days, hours, or minutes without rounding up to whole days.
- Ensure finished events are detected based on a reactive current time value so votes close at the right time.

Enhancements:
- Refactor calendar and event detail views to use precomputed event badges backed by shared utilities instead of inline time calculations.

Documentation:
- Update changelog with details about the new event badge behavior and time-remaining fixes.

Tests:
- Add unit tests covering time-remaining formatting and event badge status transitions across edge cases.