### PR TITLE
display terrain image in calendar event view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - CHANGED calendar - event badge now refreshes on its own (30s tick), closing votes on time
 - FIXED calendar - time remaining before event start rounded up to whole days ("dans 1j" for an event 1 hour away), now shown as days, hours or minutes
+- ADDED calendar - display the terrain header image on events without a custom image
 
 
 ## 2.1.1

--- a/backend/app/api/calendar.py
+++ b/backend/app/api/calendar.py
@@ -123,7 +123,7 @@ async def get_event(event_id: int, db: AsyncSession = Depends(get_db)):
             selectinload(CalendarEvent.flights).selectinload(Flight.aircraft),
             selectinload(CalendarEvent.flights).selectinload(Flight.slots).selectinload(Slot.user),
             selectinload(CalendarEvent.modules),
-            selectinload(CalendarEvent.map),
+            selectinload(CalendarEvent.map).selectinload(Module.image_header),
             selectinload(CalendarEvent.image),
             selectinload(CalendarEvent.server),
         )
@@ -152,6 +152,7 @@ async def get_event(event_id: int, db: AsyncSession = Depends(get_db)):
         deleted=event.deleted,
         map_id=event.map_id,
         map_name=event.map.name if event.map else None,
+        map_image_header_uuid=event.map.image_header.uuid if event.map and event.map.image_header else None,
         server_id=event.server_id,
         server_name=event.server.name if event.server else None,
         image_id=event.image_id,

--- a/backend/app/schemas/calendar.py
+++ b/backend/app/schemas/calendar.py
@@ -81,6 +81,7 @@ class EventDetailOut(EventListOut):
     deleted: bool
     map_id: int | None = None
     map_name: str | None = None
+    map_image_header_uuid: str | None = None
     server_id: int | None = None
     server_name: str | None = None
     image_id: int | None = None

--- a/backend/tests/integration/api/test_calendar_events.py
+++ b/backend/tests/integration/api/test_calendar_events.py
@@ -7,7 +7,9 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.calendar import CalendarEvent
-from tests.factories import EventFactory, UserFactory
+from app.models.content import File
+from app.models.module import Module
+from tests.factories import EventFactory, FileFactory, ModuleFactory, UserFactory
 
 
 async def _create_user(db: AsyncSession):
@@ -26,6 +28,24 @@ async def _create_event(db: AsyncSession, owner_id: int, **kwargs) -> CalendarEv
     await db.commit()
     await db.refresh(event)
     return event
+
+
+async def _create_file(db: AsyncSession) -> File:
+    """Create an image File and return it."""
+    file = FileFactory.build()
+    db.add(file)
+    await db.commit()
+    await db.refresh(file)
+    return file
+
+
+async def _create_map(db: AsyncSession, image_header_id: int | None = None) -> Module:
+    """Create a map module, optionally with a header image."""
+    module = ModuleFactory.build(type=Module.TYPE_MAP, image_header_id=image_header_id)
+    db.add(module)
+    await db.commit()
+    await db.refresh(module)
+    return module
 
 
 @pytest.mark.asyncio
@@ -159,3 +179,52 @@ async def test_list_events_invalid_date_returns_422(client: AsyncClient):
 
     # THEN
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_event_exposes_map_image_header_uuid(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN an event without its own image, linked to a map having a header image
+    user = await _create_user(db_session)
+    image_header = await _create_file(db_session)
+    map_module = await _create_map(db_session, image_header_id=image_header.id)
+    event = await _create_event(db_session, owner_id=user.id, map_id=map_module.id, image_id=None)
+
+    # WHEN
+    response = await client.get(f"/api/calendar/events/{event.id}")
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["image_uuid"] is None
+    assert data["map_image_header_uuid"] == image_header.uuid
+
+
+@pytest.mark.asyncio
+async def test_get_event_map_without_image_header(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN an event linked to a map that has no header image
+    user = await _create_user(db_session)
+    map_module = await _create_map(db_session)
+    event = await _create_event(db_session, owner_id=user.id, map_id=map_module.id, image_id=None)
+
+    # WHEN
+    response = await client.get(f"/api/calendar/events/{event.id}")
+
+    # THEN
+    assert response.status_code == 200
+    assert response.json()["map_image_header_uuid"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_event_without_map(client: AsyncClient, db_session: AsyncSession):
+    # GIVEN an event with neither map nor image
+    user = await _create_user(db_session)
+    event = await _create_event(db_session, owner_id=user.id, map_id=None, image_id=None)
+
+    # WHEN
+    response = await client.get(f"/api/calendar/events/{event.id}")
+
+    # THEN
+    assert response.status_code == 200
+    data = response.json()
+    assert data["map_image_header_uuid"] is None
+    assert data["image_uuid"] is None

--- a/frontend/src/types/calendar.ts
+++ b/frontend/src/types/calendar.ts
@@ -66,6 +66,7 @@ export interface EventDetail extends EventListItem {
   deleted: boolean
   map_id: number | null
   map_name: string | null
+  map_image_header_uuid: string | null
   server_id: number | null
   server_name: string | null
   image_id: number | null

--- a/frontend/src/views/EventDetailView.vue
+++ b/frontend/src/views/EventDetailView.vue
@@ -116,8 +116,8 @@ const usersChoicesMap = computed(() => {
 })
 
 const imageUrl = computed(() => {
-  if (!event.value?.image_uuid) return null
-  return `/api/files/${event.value.image_uuid}`
+  const uuid = event.value?.image_uuid ?? event.value?.map_image_header_uuid
+  return uuid ? `/api/files/${uuid}` : null
 })
 
 async function handleVote(vote: boolean | null) {


### PR DESCRIPTION
## Summary by Sourcery

Expose terrain map header images on calendar events and display them in the event detail view when no custom event image is set.

New Features:
- Include the map header image UUID in the calendar event detail API response when available.
- Display the terrain (map) header image in the event detail view as a fallback when the event has no custom image.

Enhancements:
- Extend calendar event detail schema and frontend types to carry the map header image UUID.

Documentation:
- Update the changelog to document displaying terrain header images on events without a custom image.

Tests:
- Add integration tests covering calendar event detail responses for events with map header images, maps without header images, and events without maps or images.